### PR TITLE
Ext interrupt (fix #67)

### DIFF
--- a/ExternalDevices.md
+++ b/ExternalDevices.md
@@ -23,9 +23,7 @@ One example using the external ports is provided where:
 To run the external device example, first compile the software example:
 
 ```
-cd sw
-make applications/example_external_peripheral/example_external_peripheral.hex
-cd ..
+make app-ext-periph
 ```
 
 By default, the external device example RTL code is disabled. Run fusesoc with the '--flag=use_external_device_example' option to enable it. This example is available for the sim and sim_opt targets.

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv
@@ -10,7 +10,7 @@ module core_v_mini_mcu
     parameter FPU = 0,
     parameter PULP_ZFINX = 0,
     parameter EXT_XBAR_NMASTER = 0,
-    parameter EXT_NINTERRUPT = 0
+    parameter EXT_NINTERRUPT = 6
 ) (
     input logic clk_i,
     input logic rst_ni,

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv
@@ -9,8 +9,7 @@ module core_v_mini_mcu
     parameter PULP_XPULP = 0,
     parameter FPU = 0,
     parameter PULP_ZFINX = 0,
-    parameter EXT_XBAR_NMASTER = 0,
-    parameter EXT_NINTERRUPT = 6
+    parameter EXT_XBAR_NMASTER = 0
 ) (
     input logic clk_i,
     input logic rst_ni,
@@ -36,7 +35,7 @@ module core_v_mini_mcu
     input  logic uart_rx_i,
     output logic uart_tx_o,
 
-    input logic [EXT_NINTERRUPT-1:0] intr_vector_ext_i,
+    input logic [core_v_mini_mcu_pkg::NEXT_INT-1:0] intr_vector_ext_i,
 
     inout logic [31:0] gpio_io,
 
@@ -204,7 +203,7 @@ module core_v_mini_mcu
   );
 
   peripheral_subsystem #(
-      .EXT_NINTERRUPT(EXT_NINTERRUPT)
+      .NEXT_INT(NEXT_INT)
   ) peripheral_subsystem_i (
       .clk_i,
       .rst_ni,

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -167,4 +167,9 @@ package core_v_mini_mcu_pkg;
 
   localparam int unsigned PERIPHERALS_PORT_SEL_WIDTH = SYSTEM_NPERIPHERALS > 1 ? $clog2(SYSTEM_NPERIPHERALS) : 32'd1;
 
+  // Interrupts
+  localparam PLIC_NINT = ${plic_intr_src};
+  localparam PLIC_USED_NINT = ${plic_used_intr};
+  localparam NEXT_INT = PLIC_NINT - PLIC_USED_NINT;
+
 endpackage

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -168,8 +168,8 @@ package core_v_mini_mcu_pkg;
   localparam int unsigned PERIPHERALS_PORT_SEL_WIDTH = SYSTEM_NPERIPHERALS > 1 ? $clog2(SYSTEM_NPERIPHERALS) : 32'd1;
 
   // Interrupts
-  localparam PLIC_NINT = ${plic_intr_src};
-  localparam PLIC_USED_NINT = ${plic_used_intr};
+  localparam PLIC_NINT = 64;
+  localparam PLIC_USED_NINT = 58;
   localparam NEXT_INT = PLIC_NINT - PLIC_USED_NINT;
 
 endpackage

--- a/hw/core-v-mini-mcu/peripheral_subsystem.sv
+++ b/hw/core-v-mini-mcu/peripheral_subsystem.sv
@@ -6,7 +6,7 @@ module peripheral_subsystem
   import obi_pkg::*;
   import reg_pkg::*;
 #(
-    parameter EXT_NINTERRUPT = 0
+    parameter NEXT_INT = 0
 ) (
     input logic clk_i,
     input logic rst_ni,
@@ -27,9 +27,9 @@ module peripheral_subsystem
     output logic uart_tx_en_o,
 
     //PLIC
-    input  logic [EXT_NINTERRUPT-1:0] intr_vector_ext_i,
-    output logic                      irq_plic_o,
-    output logic                      msip_o,
+    input  logic [NEXT_INT-1:0] intr_vector_ext_i,
+    output logic                irq_plic_o,
+    output logic                msip_o,
 
     //External peripheral(s)
     output reg_req_t ext_peripheral_slave_req_o,
@@ -163,14 +163,9 @@ module peripheral_subsystem
   assign intr_vector[57] = dma_intr;
 
 
-  // REMOVE ONCE PLIC HJSON IS UPDATED
-  for (genvar i = 0; i < EXT_NINTERRUPT; i++) begin
-    assign intr_vector[i+58] = intr_vector_ext_i[i];
-  end
-
-  // REMOVE ONCE PLIC HJSON IS UPDATED
-  for (genvar i = 58 + EXT_NINTERRUPT; i < rv_plic_reg_pkg::NumSrc; i++) begin
-    assign intr_vector[i] = 1'b0;
+  // External interrupts assignement
+  for (genvar i = 0; i < NEXT_INT; i++) begin
+    assign intr_vector[i+PLIC_USED_NINT] = intr_vector_ext_i[i];
   end
 
   //Address Decoder

--- a/hw/vendor/openhwgroup_cv32e20/cve2.core
+++ b/hw/vendor/openhwgroup_cv32e20/cve2.core
@@ -148,7 +148,7 @@ targets:
       - tool_veriblelint ? (files_lint_verible)
       - files_rtl
       - target_sim? (files_clk_gate)
-      - target_sim-opt? (files_clk_gate)
+      - target_sim_opt? (files_clk_gate)
     toplevel: ibex_core
     parameters:
       - tool_vivado ? (FPGA_XILINX=true)

--- a/hw/vendor/openhwgroup_cve2.vendor.hjson
+++ b/hw/vendor/openhwgroup_cve2.vendor.hjson
@@ -10,6 +10,8 @@
     rev: "5039e60cdea6a76282576ca7e93a35ee9a3ff2e9",
   },
 
+  patch_dir: "patches/openhwgroup_cv32e20",
+
   exclude_from_upstream: [
     "ci",
     "dv",

--- a/hw/vendor/patches/openhwgroup_cv32e20/cve2_core.patch
+++ b/hw/vendor/patches/openhwgroup_cv32e20/cve2_core.patch
@@ -1,0 +1,13 @@
+diff --git a/cve2.core b/cve2.core
+index ec43f9c..08e1437 100644
+--- a/cve2.core
++++ b/cve2.core
+@@ -148,7 +148,7 @@ targets:
+       - tool_veriblelint ? (files_lint_verible)
+       - files_rtl
+       - target_sim? (files_clk_gate)
+-      - target_sim-opt? (files_clk_gate)
++      - target_sim_opt? (files_clk_gate)
+     toplevel: ibex_core
+     parameters:
+       - tool_vivado ? (FPGA_XILINX=true)

--- a/mcu_cfg.hjson
+++ b/mcu_cfg.hjson
@@ -77,7 +77,10 @@
 
 
     interrupts: {
-        // always zero
+        plic_intr_src:           64,
+        plic_used_intr:          58,
+        // List of PLIC interrupt sources
+        // First one is always zero
         null_intr:               0,
         uart_intr_tx_watermark:  1,
         uart_intr_rx_watermark:  2,

--- a/mcu_cfg.hjson
+++ b/mcu_cfg.hjson
@@ -77,9 +77,6 @@
 
 
     interrupts: {
-        plic_intr_src:           64,
-        plic_used_intr:          58,
-        // List of PLIC interrupt sources
         // First one is always zero
         null_intr:               0,
         uart_intr_tx_watermark:  1,

--- a/mcu_cfg.hjson
+++ b/mcu_cfg.hjson
@@ -136,7 +136,13 @@
         intr_ack_stop:           55,
         intr_host_timeout:       56,
         dma_intr_done:           57,
-        memcopy_intr_done:       58
+        // Interrupt lines available for external interrupt sources
+        ext_intr_0:              58,
+        ext_intr_1:              59,
+        ext_intr_2:              60,
+        ext_intr_3:              61,
+        ext_intr_4:              62,
+        ext_intr_5:              63
     }
 
 }

--- a/sw/applications/example_external_peripheral/example_external_peripheral.c
+++ b/sw/applications/example_external_peripheral/example_external_peripheral.c
@@ -26,7 +26,7 @@ dif_plic_irq_id_t intr_num;
 void handler_irq_external(void) {
     // Claim/clear interrupt
     plic_res = dif_plic_irq_claim(&rv_plic, 0, &intr_num);
-    if (plic_res == kDifPlicOk && intr_num == MEMCOPY_INTR_DONE) {
+    if (plic_res == kDifPlicOk && intr_num == EXT_INTR_0) {
         external_intr_flag = 1;
     }
 }
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
 
     printf("Set MEMCOPY interrupt priority to 1...");
     // Set memcopy priority to 1 (target threshold is by default 0) to trigger an interrupt to the target (the processor)
-    plic_res = dif_plic_irq_set_priority(&rv_plic, MEMCOPY_INTR_DONE, 1);
+    plic_res = dif_plic_irq_set_priority(&rv_plic, EXT_INTR_0, 1);
     if (plic_res == kDifPlicOk) {
         printf("success\n");
     } else {
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     }
 
     printf("Enable MEMCOPY interrupt...");
-    plic_res = dif_plic_irq_set_enabled(&rv_plic, MEMCOPY_INTR_DONE, 0, kDifPlicToggleEnabled);
+    plic_res = dif_plic_irq_set_enabled(&rv_plic, EXT_INTR_0, 0, kDifPlicToggleEnabled);
     if (plic_res == kDifPlicOk) {
         printf("Success\n");
     } else {
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 
     printf("Complete interrupt...");
     plic_res = dif_plic_irq_complete(&rv_plic, 0, &intr_num);
-    if (plic_res == kDifPlicOk && intr_num == MEMCOPY_INTR_DONE) {
+    if (plic_res == kDifPlicOk && intr_num == EXT_INTR_0) {
         printf("success\n");
     } else {
         printf("fail\n;");

--- a/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
+++ b/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
@@ -126,9 +126,15 @@ extern "C" {
 #define INTR_ACQ_OVERFLOW ${intr_acq_overflow}
 #define INTR_ACK_STOP ${intr_ack_stop}
 #define INTR_HOST_TIMEOUT ${intr_host_timeout}
-#define MEMCOPY_INTR_DONE ${memcopy_intr_done}
 #define DMA_INTR_DONE ${dma_intr_done}
-#define MEMCOPY_INTR_DONE ${memcopy_intr_done}
+
+// Interrupt lines available for external interrupt sources
+#define EXT_INTR_0 ${ext_intr_0}
+#define EXT_INTR_1 ${ext_intr_1}
+#define EXT_INTR_2 ${ext_intr_2}
+#define EXT_INTR_3 ${ext_intr_3}
+#define EXT_INTR_4 ${ext_intr_4}
+#define EXT_INTR_5 ${ext_intr_5}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tb/testharness.sv
+++ b/tb/testharness.sv
@@ -59,7 +59,7 @@ module testharness #(
   obi_req_t slow_ram_slave_req;
   obi_resp_t slow_ram_slave_resp;
   // External interrupts
-  logic [6-1:0] intr_vector_ext;
+  logic [core_v_mini_mcu_pkg::NEXT_INT-1:0] intr_vector_ext;
   logic memcopy_intr;
 
   // If more external interrupt lines are needed the PLIC has to be regenerated with more interrupt sources

--- a/tb/testharness.sv
+++ b/tb/testharness.sv
@@ -59,17 +59,22 @@ module testharness #(
   obi_req_t slow_ram_slave_req;
   obi_resp_t slow_ram_slave_resp;
   // External interrupts
-  logic [testharness_pkg::EXT_NINTERRUPT-1:0] intr_vector_ext;
+  logic [6-1:0] intr_vector_ext;
   logic memcopy_intr;
 
+  // If more external interrupt lines are needed the PLIC has to be regenerated with more interrupt sources
   assign intr_vector_ext[0] = memcopy_intr;
+  assign intr_vector_ext[1] = 1'b0;
+  assign intr_vector_ext[2] = 1'b0;
+  assign intr_vector_ext[3] = 1'b0;
+  assign intr_vector_ext[4] = 1'b0;
+  assign intr_vector_ext[5] = 1'b0;
 
   core_v_mini_mcu #(
       .PULP_XPULP      (PULP_XPULP),
       .FPU             (FPU),
       .PULP_ZFINX      (PULP_ZFINX),
-      .EXT_XBAR_NMASTER(testharness_pkg::EXT_XBAR_NMASTER),
-      .EXT_NINTERRUPT  (testharness_pkg::EXT_NINTERRUPT)
+      .EXT_XBAR_NMASTER(testharness_pkg::EXT_XBAR_NMASTER)
   ) core_v_mini_mcu_i (
       .clk_i,
       .rst_ni,

--- a/tb/testharness_pkg.sv
+++ b/tb/testharness_pkg.sv
@@ -29,7 +29,6 @@ package testharness_pkg;
 
   //slave encoder
   localparam EXT_NPERIPHERALS = 1;
-  localparam EXT_NINTERRUPT = 1;
 
   // Memcopy controller (external peripheral example)
   localparam logic [31:0] MEMCOPY_CTRL_START_ADDRESS = core_v_mini_mcu_pkg::EXT_PERIPH_START_ADDRESS + 32'h0020000;

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -155,9 +155,6 @@ def main():
     i2c_start_offset  = string2int(obj['peripherals']['i2c']['offset'])
     i2c_size_address  = string2int(obj['peripherals']['i2c']['length'])
 
-    plic_intr_src = obj['interrupts']['plic_intr_src']
-    plic_used_intr = obj['interrupts']['plic_used_intr']
-
     null_intr = obj['interrupts']['null_intr']
     uart_intr_tx_watermark = obj['interrupts']['uart_intr_tx_watermark']
     uart_intr_rx_watermark = obj['interrupts']['uart_intr_rx_watermark']
@@ -258,8 +255,6 @@ def main():
         "i2c_size_address"         : i2c_size_address,
         "dma_start_offset"         : dma_start_offset,
         "dma_size_address"         : dma_size_address,
-        "plic_intr_src"            : plic_intr_src,
-        "plic_used_intr"           : plic_used_intr,
         "null_intr"                : null_intr,
         "uart_intr_tx_watermark"   : uart_intr_tx_watermark,
         "uart_intr_rx_watermark"   : uart_intr_rx_watermark,

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -213,7 +213,14 @@ def main():
     intr_ack_stop = obj['interrupts']['intr_ack_stop']
     intr_host_timeout = obj['interrupts']['intr_host_timeout']
     dma_intr_done = obj['interrupts']['dma_intr_done']
-    memcopy_intr_done = obj['interrupts']['memcopy_intr_done']
+
+    # Interrupt lines available for external interrupt sources
+    ext_intr_0 = obj['interrupts']['ext_intr_0']
+    ext_intr_1 = obj['interrupts']['ext_intr_1']
+    ext_intr_2 = obj['interrupts']['ext_intr_2']
+    ext_intr_3 = obj['interrupts']['ext_intr_3']
+    ext_intr_4 = obj['interrupts']['ext_intr_4']
+    ext_intr_5 = obj['interrupts']['ext_intr_5']
 
     kwargs = {
         "cpu_type"                 : cpu_type,
@@ -306,7 +313,12 @@ def main():
         "intr_ack_stop"            : intr_ack_stop,
         "intr_host_timeout"        : intr_host_timeout,
         "dma_intr_done"            : dma_intr_done,
-        "memcopy_intr_done"        : memcopy_intr_done,
+        "ext_intr_0"               : ext_intr_0,
+        "ext_intr_1"               : ext_intr_1,
+        "ext_intr_2"               : ext_intr_2,
+        "ext_intr_3"               : ext_intr_3,
+        "ext_intr_4"               : ext_intr_4,
+        "ext_intr_5"               : ext_intr_5,
     }
 
     ###########

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -155,6 +155,9 @@ def main():
     i2c_start_offset  = string2int(obj['peripherals']['i2c']['offset'])
     i2c_size_address  = string2int(obj['peripherals']['i2c']['length'])
 
+    plic_intr_src = obj['interrupts']['plic_intr_src']
+    plic_used_intr = obj['interrupts']['plic_used_intr']
+
     null_intr = obj['interrupts']['null_intr']
     uart_intr_tx_watermark = obj['interrupts']['uart_intr_tx_watermark']
     uart_intr_rx_watermark = obj['interrupts']['uart_intr_rx_watermark']
@@ -255,6 +258,8 @@ def main():
         "i2c_size_address"         : i2c_size_address,
         "dma_start_offset"         : dma_start_offset,
         "dma_size_address"         : dma_size_address,
+        "plic_intr_src"            : plic_intr_src,
+        "plic_used_intr"           : plic_used_intr,
         "null_intr"                : null_intr,
         "uart_intr_tx_watermark"   : uart_intr_tx_watermark,
         "uart_intr_rx_watermark"   : uart_intr_rx_watermark,


### PR DESCRIPTION
I removed the EXT_INTERRUPT from the testharness, but kept it in the top core_v_mini_mcu.sv file to keep it simple to change.