### PR TITLE
Automate peripheral integration

### DIFF
--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -188,39 +188,29 @@ package core_v_mini_mcu_pkg;
   localparam int unsigned AO_PERIPHERALS_PORT_SEL_WIDTH = AO_PERIPHERALS > 1 ? $clog2(AO_PERIPHERALS) : 32'd1;
 
   //switch-on/off peripherals
-  localparam PERIPHERALS = 5;
+<%!
+  def string2int(hex_json_string):
+      return (hex_json_string.split('x')[1]).split(',')[0]
 
-  localparam logic[31:0] PLIC_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${plic_start_offset};
-  localparam logic[31:0] PLIC_SIZE = 32'h${plic_size_address};
-  localparam logic[31:0] PLIC_END_ADDRESS = PLIC_START_ADDRESS + PLIC_SIZE;
-  localparam logic[31:0] PLIC_IDX = 32'd0;
+%>
+  localparam PERIPHERALS = ${sum(isinstance(e, dict) for e in peripherals.values())};
 
-  localparam logic[31:0] GPIO_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${gpio_start_offset};
-  localparam logic[31:0] GPIO_SIZE = 32'h${gpio_size_address};
-  localparam logic[31:0] GPIO_END_ADDRESS = GPIO_START_ADDRESS + GPIO_SIZE;
-  localparam logic[31:0] GPIO_IDX = 32'd1;
+% for peripheral, addr in peripherals.items():
+  % if isinstance(addr, dict):
+  localparam logic [31:0] ${peripheral.upper()}_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["offset"])};
+  localparam logic [31:0] ${peripheral.upper()}_SIZE = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["length"])};
+  localparam logic [31:0] ${peripheral.upper()}_END_ADDRESS = ${peripheral.upper()}_START_ADDRESS + ${peripheral.upper()}_SIZE;
+  localparam logic [31:0] ${peripheral.upper()}_IDX = 32'd${loop.index - 2};
 
-  localparam logic[31:0] I2C_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${i2c_start_offset};
-  localparam logic[31:0] I2C_SIZE = 32'h${i2c_size_address};
-  localparam logic[31:0] I2C_END_ADDRESS = I2C_START_ADDRESS + I2C_SIZE;
-  localparam logic[31:0] I2C_IDX = 32'd2;
-
-  localparam logic [31:0] RV_TIMER_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${rv_timer_start_offset};
-  localparam logic [31:0] RV_TIMER_SIZE = 32'h${rv_timer_size_address};
-  localparam logic [31:0] RV_TIMER_END_ADDRESS = RV_TIMER_START_ADDRESS + RV_TIMER_SIZE;
-  localparam logic [31:0] RV_TIMER_IDX = 32'd3;
-
-  localparam logic [31:0] SPI2_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${spi2_start_offset};
-  localparam logic [31:0] SPI2_SIZE = 32'h${spi2_size_address};
-  localparam logic [31:0] SPI2_END_ADDRESS = SPI2_START_ADDRESS + SPI2_SIZE;
-  localparam logic [31:0] SPI2_IDX = 32'd4;
+  % endif
+% endfor
 
   localparam addr_map_rule_t [PERIPHERALS-1:0] PERIPHERALS_ADDR_RULES = '{
-      '{ idx: PLIC_IDX, start_addr: PLIC_START_ADDRESS, end_addr: PLIC_END_ADDRESS },
-      '{ idx: GPIO_IDX, start_addr: GPIO_START_ADDRESS, end_addr: GPIO_END_ADDRESS },
-      '{ idx: I2C_IDX, start_addr: I2C_START_ADDRESS, end_addr: I2C_END_ADDRESS },
-      '{ idx: RV_TIMER_IDX, start_addr: RV_TIMER_START_ADDRESS, end_addr: RV_TIMER_END_ADDRESS },
-      '{ idx: SPI2_IDX, start_addr: SPI2_START_ADDRESS, end_addr: SPI2_END_ADDRESS }
+% for peripheral, addr in peripherals.items():
+  % if isinstance(addr, dict):
+      '{ idx: ${peripheral.upper()}_IDX, start_addr: ${peripheral.upper()}_START_ADDRESS, end_addr: ${peripheral.upper()}_END_ADDRESS },
+  % endif
+% endfor
   };
 
   localparam int unsigned PERIPHERALS_PORT_SEL_WIDTH = PERIPHERALS > 1 ? $clog2(PERIPHERALS) : 32'd1;

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -188,12 +188,11 @@ package core_v_mini_mcu_pkg;
   localparam int unsigned AO_PERIPHERALS_PORT_SEL_WIDTH = AO_PERIPHERALS > 1 ? $clog2(AO_PERIPHERALS) : 32'd1;
 
   //switch-on/off peripherals
+  localparam PERIPHERALS = ${sum(isinstance(e, dict) for e in peripherals.values())};
 <% 
   def string2int(hex_json_string):
       return (hex_json_string.split('x')[1]).split(',')[0]
 %>
-  localparam PERIPHERALS = ${sum(isinstance(e, dict) for e in peripherals.values())};
-
 % for peripheral, addr in peripherals.items():
   % if isinstance(addr, dict):
   localparam logic [31:0] ${peripheral.upper()}_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["offset"])};

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -187,6 +187,9 @@ package core_v_mini_mcu_pkg;
 
   localparam int unsigned AO_PERIPHERALS_PORT_SEL_WIDTH = AO_PERIPHERALS > 1 ? $clog2(AO_PERIPHERALS) : 32'd1;
 
+######################################################################
+## Automatically add all peripherals listed
+######################################################################
   //switch-on/off peripherals
   localparam PERIPHERALS = ${sum(isinstance(e, dict) for e in peripherals.values())};
 <% 

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -206,7 +206,7 @@ package core_v_mini_mcu_pkg;
   localparam addr_map_rule_t [PERIPHERALS-1:0] PERIPHERALS_ADDR_RULES = '{
 % for peripheral, addr in peripherals.items():
   % if isinstance(addr, dict):
-      '{ idx: ${peripheral.upper()}_IDX, start_addr: ${peripheral.upper()}_START_ADDRESS, end_addr: ${peripheral.upper()}_END_ADDRESS },
+      '{ idx: ${peripheral.upper()}_IDX, start_addr: ${peripheral.upper()}_START_ADDRESS, end_addr: ${peripheral.upper()}_END_ADDRESS }${"," if not loop.last else ""}
   % endif
 % endfor
   };

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -188,23 +188,21 @@ package core_v_mini_mcu_pkg;
   localparam int unsigned AO_PERIPHERALS_PORT_SEL_WIDTH = AO_PERIPHERALS > 1 ? $clog2(AO_PERIPHERALS) : 32'd1;
 
   //switch-on/off peripherals
-<%!
+<% 
   def string2int(hex_json_string):
       return (hex_json_string.split('x')[1]).split(',')[0]
-
 %>
   localparam PERIPHERALS = ${sum(isinstance(e, dict) for e in peripherals.values())};
 
 % for peripheral, addr in peripherals.items():
   % if isinstance(addr, dict):
   localparam logic [31:0] ${peripheral.upper()}_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["offset"])};
-  localparam logic [31:0] ${peripheral.upper()}_SIZE = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["length"])};
+  localparam logic [31:0] ${peripheral.upper()}_SIZE = 32'h${string2int(addr["length"])};
   localparam logic [31:0] ${peripheral.upper()}_END_ADDRESS = ${peripheral.upper()}_START_ADDRESS + ${peripheral.upper()}_SIZE;
   localparam logic [31:0] ${peripheral.upper()}_IDX = 32'd${loop.index - 2};
 
   % endif
 % endfor
-
   localparam addr_map_rule_t [PERIPHERALS-1:0] PERIPHERALS_ADDR_RULES = '{
 % for peripheral, addr in peripherals.items():
   % if isinstance(addr, dict):

--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -197,13 +197,11 @@ package core_v_mini_mcu_pkg;
       return (hex_json_string.split('x')[1]).split(',')[0]
 %>
 % for peripheral, addr in peripherals.items():
-  % if isinstance(addr, dict):
   localparam logic [31:0] ${peripheral.upper()}_START_ADDRESS = PERIPHERAL_START_ADDRESS + 32'h${string2int(addr["offset"])};
   localparam logic [31:0] ${peripheral.upper()}_SIZE = 32'h${string2int(addr["length"])};
   localparam logic [31:0] ${peripheral.upper()}_END_ADDRESS = ${peripheral.upper()}_START_ADDRESS + ${peripheral.upper()}_SIZE;
-  localparam logic [31:0] ${peripheral.upper()}_IDX = 32'd${loop.index - 2};
-
-  % endif
+  localparam logic [31:0] ${peripheral.upper()}_IDX = 32'd${loop.index};
+  
 % endfor
   localparam addr_map_rule_t [PERIPHERALS-1:0] PERIPHERALS_ADDR_RULES = '{
 % for peripheral, addr in peripherals.items():

--- a/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
+++ b/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
@@ -76,10 +76,13 @@ extern "C" {
 #define PERIPHERAL_START_ADDRESS 0x${peripheral_start_address}
 #define PERIPHERAL_SIZE 0x${peripheral_size_address}
 #define PERIPHERAL_END_ADDRESS (PERIPHERAL_START_ADDRESS + PERIPHERAL_SIZE)
-
+<% 
+  def string2int(hex_json_string):
+      return (hex_json_string.split('x')[1]).split(',')[0]
+%>
 % for name, peripheral in peripherals.items():
-#define ${name.upper()}_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${peripheral['offset']})
-#define ${name.upper()}_SIZE 0x${peripheral['length']}
+#define ${name.upper()}_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${string2int(peripheral['offset'])})
+#define ${name.upper()}_SIZE 0x${string2int(peripheral['length'])}
 #define ${name.upper()}_END_ADDRESS (${name.upper()}_START_ADDRESS + ${name.upper()}_SIZE)
 
 %endfor

--- a/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
+++ b/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
@@ -77,25 +77,12 @@ extern "C" {
 #define PERIPHERAL_SIZE 0x${peripheral_size_address}
 #define PERIPHERAL_END_ADDRESS (PERIPHERAL_START_ADDRESS + PERIPHERAL_SIZE)
 
-#define PLIC_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${plic_start_offset})
-#define PLIC_SIZE 0x${plic_size_address}
-#define PLIC_END_ADDRESS (PLIC_START_ADDRESS + PLIC_SIZE)
+% for name, peripheral in peripherals.items():
+#define ${name.upper()}_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${peripheral['offset']})
+#define ${name.upper()}_SIZE 0x${peripheral['length']}
+#define ${name.upper()}_END_ADDRESS (${name.upper()}_START_ADDRESS + ${name.upper()}_SIZE)
 
-#define GPIO_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${gpio_start_offset})
-#define GPIO_SIZE 0x${gpio_size_address}
-#define GPIO_END_ADDRESS (GPIO_START_ADDRESS + GPIO_SIZE)
-
-#define I2C_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${i2c_start_offset})
-#define I2C_SIZE 0x${i2c_size_address}
-#define I2C_END_ADDRESS (I2C_START_ADDRESS + I2C_SIZE)
-
-#define RV_TIMER_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${rv_timer_start_offset})
-#define RV_TIMER_SIZE 0x${rv_timer_size_address}
-#define RV_TIMER_END_ADDRESS (RV_TIMER_START_ADDRESS + RV_TIMER_SIZE)
-
-#define SPI2_START_ADDRESS (PERIPHERAL_START_ADDRESS + 0x${spi2_start_offset})
-#define SPI2_SIZE 0x${spi2_size_address}
-#define SPI2_END_ADDRESS (SPI2_START_ADDRESS + SPI2_SIZE)
+%endfor
 
 #define EXT_SLAVE_START_ADDRESS 0x${ext_slave_start_address}
 #define EXT_SLAVE_SIZE 0x${ext_slave_size_address}

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -901,6 +901,7 @@ def main():
         "pad_mux_process"                  : pad_mux_process,
         "pad_muxed_list"                   : pad_muxed_list,
         "total_pad_muxed"                  : total_pad_muxed,
+        **obj,
     }
 
     ###########

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -834,6 +834,7 @@ def main():
         "rv_timer_size_address"            : rv_timer_size_address,
         "spi2_start_offset"                : spi2_start_offset,
         "spi2_size_address"                : spi2_size_address,
+        "peripherals"                      : {name:{**info} for name, info in obj['peripherals'].items() if isinstance(info, dict)},
         "ext_slave_start_address"          : ext_slave_start_address,
         "ext_slave_size_address"           : ext_slave_size_address,
         "flash_mem_start_address"          : flash_mem_start_address,
@@ -901,7 +902,6 @@ def main():
         "pad_mux_process"                  : pad_mux_process,
         "pad_muxed_list"                   : pad_muxed_list,
         "total_pad_muxed"                  : total_pad_muxed,
-        **obj,
     }
 
     ###########

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -452,21 +452,6 @@ def main():
 
     peripheral_size_address = string2int(obj['peripherals']['length'])
 
-    plic_start_offset  = string2int(obj['peripherals']['plic']['offset'])
-    plic_size_address  = string2int(obj['peripherals']['plic']['length'])
-
-    gpio_start_offset  = string2int(obj['peripherals']['gpio']['offset'])
-    gpio_size_address  = string2int(obj['peripherals']['gpio']['length'])
-
-    i2c_start_offset  = string2int(obj['peripherals']['i2c']['offset'])
-    i2c_size_address  = string2int(obj['peripherals']['i2c']['length'])
-
-    rv_timer_start_offset  = string2int(obj['peripherals']['rv_timer']['offset'])
-    rv_timer_size_address  = string2int(obj['peripherals']['rv_timer']['length'])
-
-    spi2_start_offset  = string2int(obj['peripherals']['spi2']['offset'])
-    spi2_size_address  = string2int(obj['peripherals']['spi2']['length'])
-
     ext_slave_start_address = string2int(obj['ext_slaves']['address'])
     ext_slave_size_address = string2int(obj['ext_slaves']['length'])
 
@@ -824,16 +809,6 @@ def main():
         "spi_size_address"                 : spi_size_address,
         "peripheral_start_address"         : peripheral_start_address,
         "peripheral_size_address"          : peripheral_size_address,
-        "plic_start_offset"                : plic_start_offset,
-        "plic_size_address"                : plic_size_address,
-        "gpio_start_offset"                : gpio_start_offset,
-        "gpio_size_address"                : gpio_size_address,
-        "i2c_start_offset"                 : i2c_start_offset,
-        "i2c_size_address"                 : i2c_size_address,
-        "rv_timer_start_offset"            : rv_timer_start_offset,
-        "rv_timer_size_address"            : rv_timer_size_address,
-        "spi2_start_offset"                : spi2_start_offset,
-        "spi2_size_address"                : spi2_size_address,
         "peripherals"                      : {name:{**info} for name, info in obj['peripherals'].items() if isinstance(info, dict)},
         "ext_slave_start_address"          : ext_slave_start_address,
         "ext_slave_size_address"           : ext_slave_size_address,


### PR DESCRIPTION
Hi @davideschiavone,

I was playing around a bit. Thought before I start, I might as well make the integration easier. 

Automate integration of the peripherals in
- `mcu_gen.py`
- hardware side `core_v_mini_mcu_pkg.sv.tpl`
- software side  `core_v_mini_mcu.h.tpl`

It produced the same result as before. 