### PR TITLE
add tc_clk_xor2

### DIFF
--- a/hw/fpga/prim_xilinx_clk.sv
+++ b/hw/fpga/prim_xilinx_clk.sv
@@ -110,7 +110,14 @@ module cv32e40x_clock_gate #(
 
 endmodule
 
-module tc_clk_gating (
+module tc_clk_gating #(
+    /// This paramaeter is a hint for tool/technology specific mappings of this
+    /// tech_cell. It indicates wether this particular clk gate instance is
+    /// required for functional correctness or just instantiated for power
+    /// savings. If IS_FUNCTIONAL == 0, technology specific mappings might
+    /// replace this cell with a feedthrough connection without any gating.
+    parameter bit IS_FUNCTIONAL = 1'b1
+) (
     input  logic clk_i,
     input  logic en_i,
     input  logic test_en_i,
@@ -139,5 +146,15 @@ module tc_clk_mux2 (
       .clk_sel_i,
       .clk_o
   );
+
+endmodule
+
+module tc_clk_xor2 (
+    input  logic clk0_i,
+    input  logic clk1_i,
+    output logic clk_o
+);
+
+  assign clk_o = clk0_i ^ clk1_i;
 
 endmodule


### PR DESCRIPTION
I had to add this to get the `clk_int_div` to synthesis and work on the FPGA. 

I copied the code from https://github.com/esl-epfl/x-heep/blob/main/hw/vendor/pulp_platform_tech_cells_generic/src/rtl/tc_clk.sv
