### PR TITLE
Build external sources with external drivers

### DIFF
--- a/eXtendingHEEP.md
+++ b/eXtendingHEEP.md
@@ -62,8 +62,8 @@ The following is an example repository folder structure.
     │   ├── TOP
     │   │   └── top.sv
     │   └── vendor
-    │       ├── your_coprocessor
-    │       ├── your_coprocessor.vendor.hjson
+    │       ├── your_copro
+    │       ├── your_copro.vendor.hjson
     │       ├── esl_epfl_x_heep
     │       └── esl_epfl_x_heep.vendor.hjson
     ├── top.core
@@ -221,14 +221,25 @@ The following is an example repository folder structure.
     BASE
     ├── sw
     │   ├── applications
-    │   │   └── my_app
+    │   │   └── your_app
     │   │       ├── main.c
+    │   │       ├── your_app.c
+    │   │       ├── your_app.h
     │   │       └── ...
     │   ├── build -> ../hw/vendor/esl_epfl_x_heep/sw/build
     │   ├── device -> ../hw/vendor/esl_epfl_x_heep/sw/device
-    │   └── linker -> ../hw/vendor/esl_epfl_x_heep/sw/linker
+    │   ├── linker -> ../hw/vendor/esl_epfl_x_heep/sw/linker
+    │   └── external
+    │       ├── drivers
+    │       │   └── your_copro
+    │       │   	├── your_copro.c
+    │       │   	├── your_copro.h
+    │       │   	└── your_copro_defs.h -> ../../../../hw/vendor/your_copro/sw/your_copro_defs.h
+    │       └── extensions
+    │       	└── your_copro_x_heep.h
     ├── hw
     │   └── vendor
+    │       ├── your_copro
     │       ├── esl_epfl_x_heep.vendor.hjson
     │       └── esl_epfl_x_heep
     │           ├── hw
@@ -245,9 +256,9 @@ The following is an example repository folder structure.
     │   └── vendor.py
     └── ...
     
-Where `BASE` is your repository's base directory, `esl_epfl_x_heep` is the vendorized `X-HEEP` repository and `my_app` is the name of the application you intend to build. 
+Where `BASE` is your repository's base directory, `esl_epfl_x_heep` is the vendorized `X-HEEP` repository and `your_app` is the name of the application you intend to build. 
 
-## The /sw/ folder
+### The /sw/ folder
 
 The `BASE/sw/` folder must comply with `X-HEEP` repository structure and therefore include an `applications`, `build`, `device` and `linker` folder. 
 It is not compulsory for it to be on the `BASE` directory, although this is the default structure that `X-HEEP`'s Makefiles will assume if no other path is specified through the `SOURCE` variable. 
@@ -259,6 +270,17 @@ ln -s ../hw/vendor/esl_epfl_x_heep/sw/build sw/build
 ln -s ../hw/vendor/esl_epfl_x_heep/sw/device sw/device
 ln -s ../hw/vendor/esl_epfl_x_heep/sw/linker sw/linker
 ```
+
+### The /sw/applications folder
+Inside the `sw/applications/` folder you may have different applications that can be built separately. Each application is a directory named after your application, containing one and only one `main.c` file which is built during the compilation process. The folder can contain other source or header files (of any name but `main.c`).  
+
+### The /sw/external folder
+In the `external` folder you can add whatever is necessary for software to work with your coprocessor/accelerator. This might include:
+
+* Sources and header files
+* Soft links to folders or files. 
+
+The external folder or any of its subdirectories cannot contain neither a `device` nor a `applications` folder as it would collide with the respective folders inside `BASE/sw/`. It should also not contain a `main.c` file.  
 
 ### The BASE/Makefile
 The `BASE/Makefile` is your own custom Makefile. You can use it as a bridge to access the Makefile from `X-HEEP`. 
@@ -305,6 +327,6 @@ export HEEP_DIR = <path_to_x_heep_relative_to_this_directory>
 
 If you plan to store source files in a different location that the one proposed, just call `make` making the `SOURCE` path explicit. 
 ```
-make app PROJECT=my_app SOURCE=<path_to_your_sw_relative_to_x_heep_sw>
+make app PROJECT=your_app SOURCE=<path_to_your_sw_relative_to_x_heep_sw>
 ```
 Consider that inside this `sw` folder the same structure than the one proposed is required.  

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -48,7 +48,7 @@ project(${PROJECT} ASM C)
 set(CMAKE_CXX_STANDARD 14)
 
 # Set MAIN file
-SET(TARGET "main")
+SET(MAINFILE "main")
 
 # Get the correct path for the crt files and linker file
 if (${LINKER} STREQUAL "on_chip")
@@ -79,118 +79,81 @@ message( "${Magenta}LIB_CRT PATH for Cmake: ${LIB_CRT_P}${ColourReset}")
 message( "${Magenta}LINKER File for Cmake: ${LINK_FILE}${ColourReset}")
 message( "${Magenta}LIB_DRIVERS PATH for Cmake: ${LIB_DRIVERS}${ColourReset}")
 message( "${Magenta}Targetting folder: ${INC_FOLDERS}${ColourReset}")
+message( "${Magenta}Target: ${TARGET}${ColourReset}")
 
-# Define MACRO to get ALL the *.h files under sw/device (string format)
-MACRO(H_FILES_RECURSIVE return_list)
-  FILE(GLOB_RECURSE new_list *.h)
-  SET(dir_list "")
-  FOREACH(file_path ${new_list})
-  if(${file_path} MATCHES "device")
-    if(${file_path} MATCHES "target")
-      if(${file_path} MATCHES "${INC_FOLDERS}")
-        GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-        SET(dir_list ${dir_list} "-I ${dir_path} \
-        ")
-        string(REPLACE ";" "" dir_list ${dir_list})     
+
+# Make a list of the header files that need to be included
+FILE(GLOB_RECURSE new_list FOLLOW_SYMLINKS ${SOURCE_PATH}*.h)
+SET(dir_list_str "")
+FOREACH(file_path ${new_list})
+  SET(add 0) # This variable is set to 1 if the file_pth needs to be added to the list
+  if(${file_path} MATCHES "/device/")
+    if(${file_path} MATCHES "/target/") # Add it if its not in target, or if its in target/${TARGET}
+      if(${file_path} MATCHES ${TARGET})
+        SET(add 1)     
       endif()
     else()
-      GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-      SET(dir_list ${dir_list} "-I ${dir_path} \
-      ")
-      string(REPLACE ";" "" dir_list ${dir_list})
+      SET(add 1) 
     endif()
-  elseif(${file_path} MATCHES "${PROJECT}")
-    GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-    SET(dir_list ${dir_list} "-I ${dir_path} \
-    ")
-    string(REPLACE ";" "" dir_list ${dir_list}) 
-  elseif(${file_path} MATCHES "${freertos}")
-    if(${PROJECT} MATCHES "freertos")
-      GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-      SET(dir_list ${dir_list} "-I ${dir_path} \
-      ")
-      string(REPLACE ";" "" dir_list ${dir_list}) 
-    endif()
+  elseif(${file_path} MATCHES ${PROJECT})
+    SET(add 1) 
+  elseif( ( ${file_path} MATCHES "/freertos/" ) AND ( ${PROJECT} MATCHES "freertos" ) )
+    SET(add 1)  
+  elseif( ${file_path} MATCHES "/external/" )  
+    SET(add 1)        
   endif()
-  ENDFOREACH()
-  LIST(REMOVE_DUPLICATES dir_list)
-  SET(${return_list} ${dir_list})
-ENDMACRO()
 
-# Use the MACRO to get ALL the .h files
-H_FILES_RECURSIVE(h_dir_list)
+  if( add EQUAL 1 ) # If the file path mathced one of the criterion, add it to the list
+    # Get the path of the obtained directory 
+    GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
 
-# Check how many you found!
-list(LENGTH h_dir_list h_dir_list_count)
-message(STATUS "[INFO] ${h_dir_list}")
+    # Add it to the string format list
+    SET(dir_list_str ${dir_list_str} "-I ${dir_path} \
+    ")  
+    string(REPLACE ";" "" dir_list_str ${dir_list_str})
+
+    # Add it to the header list
+    SET(h_dir_list_ ${h_dir_list_} "${dir_path}")
+  endif()
+
+ENDFOREACH()
+
+LIST(REMOVE_DUPLICATES dir_list_str)
+LIST(REMOVE_DUPLICATES h_dir_list_)
+
+message(STATUS "[INFO] ${dir_list_str}")
 
 # Get all the folders to include when linking
 SET(INCLUDE_FOLDERS "-I ${RISCV}/riscv32-unknown-elf/include \
                      -I ${RISCV}/riscv32-unknown-elf/include/ \
                      -I ${ROOT_PROJECT} \
                      -I ${SOURCE_PATH} \
-					           ${h_dir_list}")
+					           ${dir_list_str}")
 
-# Define MACRO to get ALL the *.h files under sw/device (list format)
-MACRO(H_FILES_RECURSIVE_LIST return_list)
-  FILE(GLOB_RECURSE new_list *.h)
-  SET(dir_list "")
-  FOREACH(file_path ${new_list})
-  if(${file_path} MATCHES "device")
-    if(${file_path} MATCHES "target")
-      if(${file_path} MATCHES "${INC_FOLDERS}")
-        GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-        SET(dir_list ${dir_list} "${dir_path}")    
-      endif()
-    else()
-      GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-      SET(dir_list ${dir_list} "${dir_path}")
-    endif()
-  elseif(${file_path} MATCHES "${PROJECT}")
-    GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-    SET(dir_list ${dir_list} "${dir_path}")
-  elseif(${file_path} MATCHES "${freertos}")
-    if(${PROJECT} MATCHES "freertos")
-      GET_FILENAME_COMPONENT(dir_path ${file_path} PATH)
-      SET(dir_list ${dir_list} "${dir_path}")
-    endif()
+
+# Make a list of the source files that need to be linked
+FILE(GLOB_RECURSE new_list FOLLOW_SYMLINKS ${SOURCE_PATH}*.c)
+SET(c_dir_list "")
+FOREACH(file_path IN LISTS new_list)
+  SET(add 0) # This variable is set to 1 if the file_pth needs to be added to the list
+  if(${file_path} MATCHES "/device/")
+    SET(add 1) 
+  elseif( ( ${file_path} MATCHES "/${PROJECT}/" ) AND ( NOT ${file_path} MATCHES ${MAINFILE} ) )
+    SET(add 1)       
+  elseif( ${file_path} MATCHES "/external/" ) 
+    SET(add 1)          
   endif()
-  ENDFOREACH()
-  LIST(REMOVE_DUPLICATES dir_list)
-  SET(${return_list} ${dir_list})
-ENDMACRO()
 
-# Include all those directories for compiling 
-# Use the MACRO to get ALL the .h files
-H_FILES_RECURSIVE_LIST(h_dir_list_)
+  if( add EQUAL 1 ) # If the file path mathced one of the criterion, add it to the list
+    SET(c_dir_list ${c_dir_list} "${file_path}\
+    ")
+    string(REPLACE ";" "" c_dir_list ${c_dir_list})
+  endif()
 
-# Define MACRO to get ALL the *.c files under sw/device 
-MACRO(C_FILES_RECURSIVE return_list)
-    FILE(GLOB_RECURSE new_list *.c)
-    SET(dir_list "")
-    FOREACH(file_c IN LISTS new_list)
-      #message(${file_c})
-      if(${file_c} MATCHES "device")
-        SET(dir_list ${dir_list} "${file_c} \
-        ")
-        string(REPLACE ";" "" dir_list ${dir_list})
-      elseif(${file_c} MATCHES "${PROJECT}")
-        if(NOT ${file_c} MATCHES "main")
-          SET(dir_list ${dir_list} "${file_c} \
-          ")
-          string(REPLACE ";" "" dir_list ${dir_list})          
-        endif()
-      endif()
-    ENDFOREACH()
-    LIST(REMOVE_DUPLICATES dir_list)
-    SET(${return_list} ${dir_list})
-ENDMACRO()
+ENDFOREACH()
 
-# Use the MACRO to get ALL the .c files
-C_FILES_RECURSIVE(c_dir_list)
-# Check how many you found!
-list(LENGTH c_dir_list c_dir_list_count)
-#message(STATUS "[INFO] ${c_dir_list}")
+LIST(REMOVE_DUPLICATES c_dir_list)
+
 
 # Get all the files to include when linking
 SET(LINKED_FILES    "${LIB_CRT_P}crt0.S \
@@ -252,20 +215,20 @@ endif()
 #add_subdirectory(device/lib/drivers)
 #add_subdirectory(device/lib/runtime)
 
-set(SOURCES ${SOURCE_PATH}applications/${PROJECT}/${TARGET}.c)
+set(SOURCES ${SOURCE_PATH}applications/${PROJECT}/${MAINFILE}.c)
 
 # add the executable
-add_executable(${TARGET}.elf ${SOURCES})  
+add_executable(${MAINFILE}.elf ${SOURCES})  
 
 # add include directories to compilation
-target_include_directories(${TARGET}.elf PUBLIC ${h_dir_list_})
+target_include_directories(${MAINFILE}.elf PUBLIC ${h_dir_list_})
 
 # linking the libraries
-#target_link_libraries(${TARGET}.elf base)
-#target_link_libraries(${TARGET}.elf drivers)
-#target_link_libraries(${TARGET}.elf runtime)
+#target_link_libraries(${MAINFILE}.elf base)
+#target_link_libraries(${MAINFILE}.elf drivers)
+#target_link_libraries(${MAINFILE}.elf runtime)
 if(${PROJECT} MATCHES "freertos")
-  target_link_libraries(${TARGET}.elf freertos_kernel)
+  target_link_libraries(${MAINFILE}.elf freertos_kernel)
 endif()
 
 # Setting-up the linker
@@ -273,13 +236,13 @@ SET(LINKER_SCRIPT "${LINK_FOLDER}/${LINK_FILE}")
 message( "${Magenta}Linker file: ${LINKER_SCRIPT}${ColourReset}")
 
 # Setting-up the properties, elf is 
-set_target_properties(${TARGET}.elf PROPERTIES LINK_DEPENDS "${LINKER_SCRIPT}")
+set_target_properties(${MAINFILE}.elf PROPERTIES LINK_DEPENDS "${LINKER_SCRIPT}")
 
 # Linker control
 SET(CMAKE_EXE_LINKER_FLAGS  "-T ${LINKER_SCRIPT}  \
                             ${INCLUDE_FOLDERS} \
                              -static ${LINKED_FILES} \
-                             -Wl,-Map=${TARGET}.map \
+                             -Wl,-Map=${MAINFILE}.map \
                              -L ${RISCV}/riscv32-unknown-elf/lib \
                              -lc -lm -lgcc -flto \
                             -ffunction-sections -fdata-sections -specs=nano.specs")
@@ -288,8 +251,8 @@ message( "${Magenta}Lib Folder RISCV-GCC: ${RISCV}/riscv32-unknown-elf/lib${Colo
 SET(CMAKE_VERBOSE_MAKEFILE on)
 
 # To make sure that .obj files are created and fetched from the same path. 
-# When setting an inner path to add_executable, .obj files are stored in ${TARGET}.elf.dir/<relative path>
-# but when an outside directory is provided, they are stored in ${TARGET}.elf.dir/<absolute path>.
+# When setting an inner path to add_executable, .obj files are stored in ${MAINFILE}.elf.dir/<relative path>
+# but when an outside directory is provided, they are stored in ${MAINFILE}.elf.dir/<absolute path>.
 # To prevent this, if the SOURCE_PATH is the ROOT_PROJECT (X-HEEP source files will be used), no further path is to be added to the fetch directory.
 if( ${SOURCE_PATH} STREQUAL ${ROOT_PROJECT} )
     SET(OBJ_PATH "")
@@ -300,43 +263,36 @@ endif()
 # Specify that we want to link with GCC even if we are compiling with clang
 if (${COMPILER} MATCHES "clang")
   set( CMAKE_C_LINK_EXECUTABLE "${CMAKE_LINKER} ${COMPILER_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS} \
-                                ${SOURCE_PATH}build/CMakeFiles/${TARGET}.elf.dir/${OBJ_PATH}applications/${PROJECT}/${TARGET}.c.obj \
-                                -o ${TARGET}.elf")
+                                ${SOURCE_PATH}build/CMakeFiles/${MAINFILE}.elf.dir/${OBJ_PATH}applications/${PROJECT}/${MAINFILE}.c.obj \
+                                -o ${MAINFILE}.elf")
 endif()
 
 # Post processing command to create a disassembly file 
-add_custom_command(TARGET ${TARGET}.elf POST_BUILD
-        COMMAND ${CMAKE_OBJDUMP} -S  ${TARGET}.elf > ${TARGET}.disasm
+add_custom_command(TARGET ${MAINFILE}.elf POST_BUILD
+        COMMAND ${CMAKE_OBJDUMP} -S  ${MAINFILE}.elf > ${MAINFILE}.disasm
         COMMENT "Invoking: Disassemble")
 
 # Post processing command to create a hex file 
 if((${LINKER} STREQUAL "flash_load") OR (${LINKER} STREQUAL "flash_exec"))
-    add_custom_command(TARGET ${TARGET}.elf POST_BUILD
-            COMMAND ${CMAKE_OBJCOPY} -O verilog --adjust-vma=-0x40000000 ${TARGET}.elf  ${TARGET}.hex 
+    add_custom_command(TARGET ${MAINFILE}.elf POST_BUILD
+            COMMAND ${CMAKE_OBJCOPY} -O verilog --adjust-vma=-0x40000000 ${MAINFILE}.elf  ${MAINFILE}.hex 
             COMMENT "Invoking: Hexdump")
 else()
-    add_custom_command(TARGET ${TARGET}.elf POST_BUILD
-            COMMAND ${CMAKE_OBJCOPY} -O verilog  ${TARGET}.elf  ${TARGET}.hex 
+    add_custom_command(TARGET ${MAINFILE}.elf POST_BUILD
+            COMMAND ${CMAKE_OBJCOPY} -O verilog  ${MAINFILE}.elf  ${MAINFILE}.hex 
             COMMENT "Invoking: Hexdump")
 endif()
 
-add_custom_command(TARGET ${TARGET}.elf POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -O binary  ${TARGET}.elf  ${TARGET}.bin
+add_custom_command(TARGET ${MAINFILE}.elf POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O binary  ${MAINFILE}.elf  ${MAINFILE}.bin
         COMMENT "Invoking: Hexdump")
 
 # Pre-processing command to create disassembly for each source file
-foreach (SRC_MODULE ${TARGET} )
-  add_custom_command(TARGET ${TARGET}.elf 
+foreach (SRC_MODULE ${MAINFILE} )
+  add_custom_command(TARGET ${MAINFILE}.elf 
                      PRE_LINK
-                     COMMAND ${CMAKE_OBJDUMP} -S ${SOURCE_PATH}build/CMakeFiles/${TARGET}.elf.dir/${OBJ_PATH}applications/${PROJECT}/${SRC_MODULE}.c.obj > ${SRC_MODULE}.s
-                     COMMENT "Invoking: Disassemble ( CMakeFiles/${TARGET}.dir/${SRC_MODULE}.c.obj)")
+                     COMMAND ${CMAKE_OBJDUMP} -S ${SOURCE_PATH}build/CMakeFiles/${MAINFILE}.elf.dir/${OBJ_PATH}applications/${PROJECT}/${SRC_MODULE}.c.obj > ${SRC_MODULE}.s
+                     COMMENT "Invoking: Disassemble ( CMakeFiles/${MAINFILE}.dir/${SRC_MODULE}.c.obj)")
 endforeach()
 
-# Adding gdb command - TBD
-#add_custom_target(gdb DEPENDS ${TARGET}.elf)
-#add_custom_command(TARGET gdb
-#    COMMAND ${CMAKE_C_GDB} ${TARGET}.elf -x gdbInit &)
-
 SET(DCMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-#message( FATAL_ERROR "You can not do this at all, CMake will exit." )

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -53,10 +53,10 @@ source_path := $(realpath $(mkfile_path)/$(SOURCE))
 $(info $$You are fetching sources from $(source_path) )
 
 
-SOURCE_PATH 	= $(source_path)/
-ROOT_PROJECT	= $(mkfile_path)/
-INC_FOLDERS		= $(mkfile_path)/device/target/$(TARGET)/
-LINK_FOLDER		= $(mkfile_path)/linker
+SOURCE_PATH   		   = $(source_path)/
+ROOT_PROJECT               = $(mkfile_path)/
+INC_FOLDERS                = $(mkfile_path)/device/target/$(TARGET)/
+LINK_FOLDER                = $(mkfile_path)/linker
 
 # CMake keyword
 CMAKE_DIR=cmake

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -53,10 +53,10 @@ source_path := $(realpath $(mkfile_path)/$(SOURCE))
 $(info $$You are fetching sources from $(source_path) )
 
 
-SOURCE_PATH   		   = $(source_path)/
-ROOT_PROJECT               = $(mkfile_path)/
-INC_FOLDERS                = $(mkfile_path)/device/target/$(TARGET)/
-LINK_FOLDER                = $(mkfile_path)/linker
+SOURCE_PATH   		   	= $(source_path)/
+ROOT_PROJECT            = $(mkfile_path)/
+INC_FOLDERS             = $(mkfile_path)/device/target/$(TARGET)/
+LINK_FOLDER             = $(mkfile_path)/linker
 
 # CMake keyword
 CMAKE_DIR=cmake

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -53,10 +53,10 @@ source_path := $(realpath $(mkfile_path)/$(SOURCE))
 $(info $$You are fetching sources from $(source_path) )
 
 
-SOURCE_PATH   		   	= $(source_path)/
-ROOT_PROJECT            = $(mkfile_path)/
-INC_FOLDERS             = $(mkfile_path)/device/target/$(TARGET)/
-LINK_FOLDER             = $(mkfile_path)/linker
+SOURCE_PATH 	= $(source_path)/
+ROOT_PROJECT	= $(mkfile_path)/
+INC_FOLDERS		= $(mkfile_path)/device/target/$(TARGET)/
+LINK_FOLDER		= $(mkfile_path)/linker
 
 # CMake keyword
 CMAKE_DIR=cmake

--- a/sw/cmake/targets.mak
+++ b/sw/cmake/targets.mak
@@ -29,6 +29,7 @@ build/Makefile : CMakeLists.txt ${CMAKE_DIR}/riscv.cmake
 			-DCMAKE_TOOLCHAIN_FILE=../${CMAKE_DIR}/riscv.cmake \
 			-DROOT_PROJECT=${ROOT_PROJECT} \
 			-DSOURCE_PATH=${SOURCE_PATH} \
+			-DTARGET=${TARGET} \
 			-DPROJECT:STRING=${PROJECT} \
 			-DRISCV:STRING=${RISCV} \
 			-DINC_FOLDERS:STRING=${INC_FOLDERS} \


### PR DESCRIPTION
## Problem
When eXtending HEEP, not only application sources are required, but sometimes also driver files. 
In the original change in the compilation process, this was not considered because: 
* In some of the applications that were used to test the process this was not required. 
* A bug in `CMakeLists.txt` was anyways including header files that did not match any of the required patterns. 

This issue only appeared with the need to include source files as well. 

## Solution
The solution to this problem has two fronts:
 
* Changes done in `CMakeLists`. It now searches: 
  * for included and linked files inside the provided `sw` directory (vs. its own directory, as it did before). 
  * recursively into linked folders.
  * for any file inside an `external` folder. 
* Changes that need to be done in the user repository folder structure (only affects the documentation `eXtendingHEEP.md`):
  * Files can be organized inside an `external` folder to include whatever software files/folders that are not application or X-HEEP's. 
  * Inside the application directory, now all header and source files are included and linked respectively. 

## Other changes
Additionally, some minor changes were performed inside the `CMakeLists.txt` file and when invoking it: 
* The `TARGET` variable was renamed as `MAINFILE`, as its value as `main`, and it was deemed good to differentiate it from the compilation target (simulation, FPGA, etc..)
* A `TARGET` variable is passed to it from the `targets.mak` file. It can be (`sim`, `pynq-z2`, etc..) and is used to identify the target folder (i.e. determine if it needs to include `sim/x-heep.h` or `pynq-z2/x-heep.h`, vs. previously selecting the file by comparing its path with the (expanded) path coming in `INC_FOLDERS`, which now is not consistent as files paths through linked directories are not expand).

## Performed Tests
These changes were tested by: 
* Building two different applications of the `CGRA-X-HEEP` project. One of them only has header files in the application folder. The other has header and source files. Both need to use the `CGRA` drivers located in a `external/drivers` (one of which is a link to a file inside the vendorized CGRA) and a file containing integration information (`cgra_x_heep.h`) in a folder `external/extensions`. 
* Building the `hello_world` and `dma_example` applications from inside X-HEEP using the `make app PROJECT=dma_example SOURCE='.'` command. 

## Tests for reviewers
To make sure that no configuration (unknowingly) positively affected the results of my tests, I suggest re-doing the aforementioned tests (or equivalent ones).  
