### PR TITLE
Minor fixes for apps to be built successfully

### DIFF
--- a/sw/applications/example_power_gating_core/main.c
+++ b/sw/applications/example_power_gating_core/main.c
@@ -13,7 +13,6 @@
 #include "soc_ctrl.h"
 #include "rv_plic.h"
 #include "rv_plic_regs.h"
-#include "fast_intr_ctrl.h"
 #include "gpio.h"
 
 static rv_timer_t timer_0_1;
@@ -26,10 +25,6 @@ static gpio_t gpio;
 
 int main(int argc, char *argv[])
 {
-    // Setup fast interrupt controller
-    fast_intr_ctrl_t fast_intr_ctrl;
-    fast_intr_ctrl.base_addr = mmio_region_from_addr((uintptr_t)FAST_INTR_CTRL_START_ADDRESS);
-
     // Setup power_manager
     mmio_region_t power_manager_reg = mmio_region_from_addr(POWER_MANAGER_START_ADDRESS);
     power_manager.base_addr = power_manager_reg;

--- a/sw/applications/example_virtual_flash/main.c
+++ b/sw/applications/example_virtual_flash/main.c
@@ -75,9 +75,9 @@ void write_to_flash(spi_host_t *SPI, dma_t *DMA, uint16_t *data, uint32_t byte_c
 
     // Set the correct SPI-DMA mode:
     // (0) disable
-    // (1) receive from SPI (use SPI_START_ADDRESS for spi_host pointer)
-    // (2) send to SPI (use SPI_START_ADDRESS for spi_host pointer)
-    // (3) receive from SPI FLASH (use SPI2_FLASH_START_ADDRESS for spi_host pointer)
+    // (1) receive from SPI (use SPI2_START_ADDRESS for spi_host pointer)
+    // (2) send to SPI (use SPI2_START_ADDRESS for spi_host pointer)
+    // (3) receive from SPI FLASH (use SPI_FLASH_START_ADDRESS for spi_host pointer)
     // (4) send to SPI FLASH (use SPI_FLASH_START_ADDRESS for spi_host pointer)
     dma_set_spi_mode(DMA, (uint32_t) 4); // The DMA will wait for the SPI FLASH TX FIFO ready signal
     dma_set_data_type(DMA, (uint32_t) 1); // 1 is for 16-bits

--- a/sw/applications/spi_flash_write/main.c
+++ b/sw/applications/spi_flash_write/main.c
@@ -182,9 +182,9 @@ int main(int argc, char *argv[])
     dma_set_write_ptr(&dma, (uint32_t) fifo_ptr_tx); // copy data address
     // Set the correct SPI-DMA mode:
     // (0) disable
-    // (1) receive from SPI (use SPI_START_ADDRESS for spi_host pointer)
-    // (2) send to SPI (use SPI_START_ADDRESS for spi_host pointer)
-    // (3) receive from SPI FLASH (use SPI2_FLASH_START_ADDRESS for spi_host pointer)
+    // (1) receive from SPI (use SPI2_START_ADDRESS for spi_host pointer)
+    // (2) send to SPI (use SPI2_START_ADDRESS for spi_host pointer)
+    // (3) receive from SPI FLASH (use SPI_FLASH_START_ADDRESS for spi_host pointer)
     // (4) send to SPI FLASH (use SPI_FLASH_START_ADDRESS for spi_host pointer)
     #ifndef USE_SPI_FLASH
         dma_set_spi_mode(&dma, (uint32_t) 2); // The DMA will wait for the SPI TX FIFO ready signal


### PR DESCRIPTION
In order for all apps to be successfully built, the  `fast_intr_ctrl_t` call had to be removed from the `example_power-gating_core.c` file. 

Additionally fixed two comments about the new SPI name. 