### PR TITLE
fix example_pdm2pcm app

### DIFF
--- a/sw/applications/example_pdm2pcm/main.c
+++ b/sw/applications/example_pdm2pcm/main.c
@@ -26,6 +26,12 @@
 
 #include "groundtruth.h"
 
+#include "x-heep.h"
+
+#ifdef TARGET_PYNQ_Z2
+  #pragma message ( "This app does NOT work on the Pynq-Z2 board!" )
+#endif
+
 int main(int argc, char *argv[])
 {
     printf("PDM2PCM DEMO\n");


### PR DESCRIPTION
Added compilation warning to avoid execution on the Pynq-Z2 board.