### PR TITLE
Added command in CI to include all peripherals before building.

### DIFF
--- a/.github/workflows/build-apps-job/setup.sh
+++ b/.github/workflows/build-apps-job/setup.sh
@@ -19,6 +19,8 @@ echo ========================================
 # The variable could also be obtained from the container.
 export RISCV='/home/root/tools/riscv' &&\
 
+# All peripherals are included to make sure all apps can be built.
+sed 's/is_included: "no",/is_included: "yes",/' -i mcu_cfg.hjson
 # The MCU is generated with various memory banks to avoid example code not fitting. 	
 make mcu-gen MEMORY_BANKS=6
 


### PR DESCRIPTION
In a near future apps while raise an error when being built if a peripheral they use is not included. We need to make sure the CI to test all apps will not fail solely because of this, that is not an error per se

---

This is achieved by modifying the `mcu_cfg.hjson` file to include all peripherals before calling `mcu-gen`. 

---

To test this change it's necessary to raise an error if a peripheral is not included. This is not done by default in the main branch right now. 

It can be tested checking out to PR #288 and reverting the usage of a `CI_list.txt` with hardcoded apps to be tested: 
```bash
+ APPS=$(\ls sw/applications/) &&\   
- APPS=$(\cat sw/applications/ci_list.txt) &&\ 
```

Alternatively, it the warning message in casea peripheral is not included can be upgraded to an error
```C
#ifndef <SOME_PERIPHERAL>_IS_INCLUDED
  #error ( "This app does NOT work as the SOME_PERIPHERAL> peripheral is not included" )
#endif
```
---

### Important

PR #288 needs to revert the above change and delete the `CI_list.txt`