### PR TITLE
Fix FuseSoC compatibility with Edalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ linux_femu/rtl/linux_femu.sv
 .venv/
 
 # ignore the following hw automatically generated files
+environment.yml
 core-v-mini-mcu.upf
 tb/tb_util.svh
 hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv
@@ -48,3 +49,7 @@ sw/device/lib/drivers/**/*_structs.h
 
 # openroad
 flow/OpenROAD-flow-scripts
+
+# User-dependent configuration files
+.vscode
+private/

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -7,7 +7,7 @@ mako==1.1.6
 jsonref==0.2
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
+git+https://github.com/davideschiavone/fusesoc.git@ot#egg=fusesoc >= 1.11.0
 
 # Install edalize by hand as pip install git+https://github.com/davideschiavone/edalize.git
 git+https://github.com/davideschiavone/edalize.git


### PR DESCRIPTION
## Motivation
Recent versions of Edalize, including the [one](https://github.com/davideschiavone/edalize) used in `x-heep`, expose the `get_edatools` method as part of the `edalize.edatool` package instead of simply `edalize` as done previously. This breaks compatibility with the lowRISC's version of [FuseSoC](https://github.com/lowRISC/fusesoc/tree/ot) used in `x-heep`, resulting in `x-heep` build process failing.

## Solution
A fix to this issue has been proposed in a [pull request](https://github.com/davideschiavone/fusesoc/pull/1) to a separate [fork](https://github.com/davideschiavone/fusesoc/tree/ot) of FuseSoC. This fixes the build process.

> Because this pull request depends on the one mentioned above, do _not_ merge it until that one is merged.

### Future development
A better solution would be to switch to a more recent version of FuseSoC, that provide an improved dependency manager and better support to features like `flags`. However, switching to lowRISC's `master` branch would break compatibility with some of the Opentitan modules used in `x-heep` (e.g., the `rv_plic`). Therefore, upgrading FuseSoC implies upgrading Opentitan's modules as well, which likely not straightforward.

## Status
- [x] Test `x-heep` build process
- [ ] Merge [this](https://github.com/davideschiavone/fusesoc/pull/1) pull request
- [ ] [optional] Upgrade to a newer version of FuseSoC