### PR TITLE
Interrupt ID to the intr handlers of the PLIC

### DIFF
--- a/sw/applications/example_gpio_cnt/main.c
+++ b/sw/applications/example_gpio_cnt/main.c
@@ -49,7 +49,7 @@ Notes:
 // plic_params_t rv_plic_params;
 // plic_t rv_plic;
 plic_result_t plic_res;
-// plic_irq_id_t intr_num;
+// uint32_t intr_num;
 
 // void handler_irq_external(void) {
 //     // Claim/clear interrupt

--- a/sw/applications/example_power_gating_core/main.c
+++ b/sw/applications/example_power_gating_core/main.c
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
     }
     CSR_SET_BITS(CSR_REG_MSTATUS, 0x8);
 
-    plic_irq_id_t intr_num;
+    uint32_t intr_num;
     plic_irq_complete(&intr_num);
 #endif
 

--- a/sw/applications/example_virtual_flash/main.c
+++ b/sw/applications/example_virtual_flash/main.c
@@ -24,7 +24,7 @@
 
 // Interrupt controller variables
 plic_result_t plic_res;
-plic_irq_id_t intr_num;
+uint32_t intr_num;
 
 //volatile int8_t timer_flag;
 volatile int8_t spi_intr_flag;

--- a/sw/applications/i2s/main.c
+++ b/sw/applications/i2s/main.c
@@ -67,7 +67,7 @@
 
 // Interrupt controller variables
 plic_result_t plic_res;
-plic_irq_id_t intr_num;
+uint32_t intr_num;
 
 
 // I2s
@@ -86,7 +86,7 @@ int8_t dma_intr_flag;
 //
 // ISR
 //
-void handler_irq_i2s(void) {
+void handler_irq_i2s(uint32_t id) {
     i2s_interrupt_flag = 1;
 }
 

--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -1145,7 +1145,7 @@ void fic_irq_dma(void)
 /** 
  * This is a non-weak implementation of the function declared in rv_plic.c
  */
-void handler_irq_dma(void) 
+void handler_irq_dma(uint32_t id) 
 {
     /*
      * Call the weak implementation provided in this module, 

--- a/sw/device/lib/drivers/rv_plic/rv_plic.c
+++ b/sw/device/lib/drivers/rv_plic/rv_plic.c
@@ -91,7 +91,7 @@ handler_funct_t handlers[] = {&handler_irq_uart,
 /**
  * Returns the irq_sources_t source type of a given irq source ID
 */
-static irq_sources_t plic_get_irq_src_type(plic_irq_id_t irq_id);
+static irq_sources_t plic_get_irq_src_type(uint32_t irq_id);
 
 /**
  * Get an IE, IP or LE register offset (IE0_0, IE01, ...) from an IRQ source ID.
@@ -100,7 +100,7 @@ static irq_sources_t plic_get_irq_src_type(plic_irq_id_t irq_id);
  * accommodate all the bits (1 bit per IRQ source). This function calculates
  * the offset for a specific IRQ source ID (ID 32 would be IE01, ...).
  */
-static ptrdiff_t plic_offset_from_reg0(plic_irq_id_t irq);
+static ptrdiff_t plic_offset_from_reg0(uint32_t irq);
 
 /**
  * 
@@ -111,7 +111,7 @@ static ptrdiff_t plic_offset_from_reg0(plic_irq_id_t irq);
  * the bit position within a register for a specific IRQ source ID (ID 32 would
  * be bit 0).
  */
-static uint8_t plic_irq_bit_index(plic_irq_id_t irq);
+static uint8_t plic_irq_bit_index(uint32_t irq);
 
 /****************************************************************************/
 /**                                                                        **/
@@ -139,44 +139,44 @@ uint8_t plic_intr_flag = 0;
 /**                                                                        **/
 /****************************************************************************/
 
-__attribute__((weak, optimize("O0"))) void handler_irq_uart(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_uart(uint32_t id) {
 
 } 
 
-__attribute__((weak, optimize("O0"))) void handler_irq_gpio(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_gpio(uint32_t id) {
   
 }
 
-__attribute__((weak, optimize("O0"))) void handler_irq_i2c(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_i2c(uint32_t id) {
   
 }
 
-__attribute__((weak, optimize("O0"))) void handler_irq_spi(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_spi(uint32_t id) {
   
 }
 
-
-__attribute__((weak, optimize("O0"))) void handler_irq_i2s(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_i2s(uint32_t id) {
 
 } 
-__attribute__((weak, optimize("O0"))) void handler_irq_dma(void) {
-  
+
+__attribute__((weak, optimize("O0"))) void handler_irq_dma(uint32_t id) {
+
 }
 
-__attribute__((weak, optimize("O0"))) void handler_irq_ext(void) {
+__attribute__((weak, optimize("O0"))) void handler_irq_ext(uint32_t id) {
 
 }
 
 void handler_irq_external(void)
 {
-  plic_irq_id_t int_id = 0;
+  uint32_t int_id = 0;
   plic_result_t res = plic_irq_claim(&int_id);
   irq_sources_t type = plic_get_irq_src_type(int_id);
 
   if(type != IRQ_BAD)
   {
     // Calls the proper handler
-    handlers[type]();
+    handlers[type](int_id);
     plic_intr_flag = 1;
 
     plic_irq_complete(&int_id);
@@ -232,7 +232,7 @@ plic_result_t plic_Init(void)
 }
 
 
-plic_result_t plic_irq_set_enabled(plic_irq_id_t irq,
+plic_result_t plic_irq_set_enabled(uint32_t irq,
                                        plic_toggle_t state)
 {
   if(irq >= RV_PLIC_PARAM_NUM_SRC)
@@ -263,7 +263,7 @@ plic_result_t plic_irq_set_enabled(plic_irq_id_t irq,
 }
 
 
-plic_result_t plic_irq_get_enabled(plic_irq_id_t irq,
+plic_result_t plic_irq_get_enabled(uint32_t irq,
                                        plic_toggle_t *state)
 {
   if(irq >= RV_PLIC_PARAM_NUM_SRC)
@@ -285,7 +285,7 @@ plic_result_t plic_irq_get_enabled(plic_irq_id_t irq,
 }
 
 
-plic_result_t plic_irq_set_trigger(plic_irq_id_t irq,
+plic_result_t plic_irq_set_trigger(uint32_t irq,
                                            plic_irq_trigger_t trigger)
 {
   if(irq >= RV_PLIC_PARAM_NUM_SRC)
@@ -310,7 +310,7 @@ plic_result_t plic_irq_set_trigger(plic_irq_id_t irq,
 }
 
 
-plic_result_t plic_irq_set_priority(plic_irq_id_t irq, uint32_t priority)
+plic_result_t plic_irq_set_priority(uint32_t irq, uint32_t priority)
 {
   if(irq >= RV_PLIC_PARAM_NUM_SRC || priority > plicMaxPriority)
   {
@@ -338,7 +338,7 @@ plic_result_t plic_target_set_threshold(uint32_t threshold)
 }
 
 
-plic_result_t plic_irq_is_pending(plic_irq_id_t irq,
+plic_result_t plic_irq_is_pending(uint32_t irq,
                                           bool *is_pending)
 {
   if(irq >= RV_PLIC_PARAM_NUM_SRC || is_pending == NULL)
@@ -358,7 +358,7 @@ plic_result_t plic_irq_is_pending(plic_irq_id_t irq,
 }
 
 
-plic_result_t plic_irq_claim(plic_irq_id_t *claim_data) 
+plic_result_t plic_irq_claim(uint32_t *claim_data) 
 {
   if (claim_data == NULL) 
   {
@@ -371,7 +371,7 @@ plic_result_t plic_irq_claim(plic_irq_id_t *claim_data)
 }
 
 
-plic_result_t plic_irq_complete(const plic_irq_id_t *complete_data) 
+plic_result_t plic_irq_complete(const uint32_t *complete_data) 
 {
   if (complete_data == NULL) 
   {
@@ -410,7 +410,7 @@ plic_result_t plic_software_irq_is_pending(void)
 /**                                                                        **/
 /****************************************************************************/
 
-static irq_sources_t plic_get_irq_src_type(plic_irq_id_t irq_id)
+static irq_sources_t plic_get_irq_src_type(uint32_t irq_id)
 {
   if (irq_id < UART_ID_START || irq_id > EXT_IRQ_END)
   {
@@ -432,7 +432,8 @@ static irq_sources_t plic_get_irq_src_type(plic_irq_id_t irq_id)
   {
     return IRQ_SPI_SRC;
   }
-  else if (irq_id == I2S_ID) {
+  else if (irq_id == I2S_ID) 
+  {
     return IRQ_I2S_SRC;
   }
   else if (irq_id == DMA_ID)
@@ -446,12 +447,12 @@ static irq_sources_t plic_get_irq_src_type(plic_irq_id_t irq_id)
 
 }
 
-static ptrdiff_t plic_offset_from_reg0(plic_irq_id_t irq) 
+static ptrdiff_t plic_offset_from_reg0(uint32_t irq) 
 {
   return irq / RV_PLIC_PARAM_REG_WIDTH;
 }
 
-static uint8_t plic_irq_bit_index(plic_irq_id_t irq) 
+static uint8_t plic_irq_bit_index(uint32_t irq) 
 {
   return irq % RV_PLIC_PARAM_REG_WIDTH;
 }

--- a/sw/device/lib/drivers/rv_plic/rv_plic.h
+++ b/sw/device/lib/drivers/rv_plic/rv_plic.h
@@ -101,7 +101,7 @@
  * Each element will be initialized to be the address of the handler function
  * relative to its index. So each element will be a callable function.
 */
-typedef void (*handler_funct_t)(void);
+typedef void (*handler_funct_t)(uint32_t);
 
 
 /**
@@ -115,20 +115,6 @@ typedef void (*handler_funct_t)(void);
  * `NumTarget` instantiation parameter of the `rv_plic` device.
  */
 typedef uint32_t plic_target_t;
-
-
-/**
- * A PLIC interrupt source identifier.
- *
- * This corresponds to a specific interrupt, and not the device it originates
- * from.
- *
- * This is an unsigned 32-bit value that is at least zero and is less than the
- * `NumSrc` instantiation parameter of the `rv_plic` device.
- *
- * The value 0 corresponds to "No Interrupt".
- */
-typedef uint32_t plic_irq_id_t;
 
 
 /**
@@ -227,37 +213,37 @@ extern uint8_t plic_intr_flag;
 /**
  * IRQ handler for UART 
 */
-void handler_irq_uart(void);
+void handler_irq_uart(uint32_t id);
 
 /**
  * IRQ handler for GPIO 
 */
-void handler_irq_gpio(void);
+void handler_irq_gpio(uint32_t id);
 
 /**
  * IRQ handler for I2C 
 */
-void handler_irq_i2c(void);
+void handler_irq_i2c(uint32_t id);
 
 /**
  * IRQ handler for SPI 
 */
-void handler_irq_spi(void);
+void handler_irq_spi(uint32_t id);
 
 /**
  * IRQ handler for I2S 
 */
-void handler_irq_i2s(void);
+void handler_irq_i2s(uint32_t id);
 
 /**
  * IRQ handler for DMA window 
 */
-void handler_irq_dma(void);
+void handler_irq_dma(uint32_t id);
 
 /**
  * IRQ handler for external interrupts sources
 */
-void handler_irq_ext(void);
+void handler_irq_ext(uint32_t id);
 
 
 /**
@@ -294,7 +280,7 @@ plic_result_t plic_Init(void);
  * @param state The new toggle state for the interrupt
  * @return The result of the operation
 */
-plic_result_t plic_irq_set_enabled(plic_irq_id_t irq,
+plic_result_t plic_irq_set_enabled(uint32_t irq,
                                        plic_toggle_t state);
 
 
@@ -312,7 +298,7 @@ plic_result_t plic_irq_set_enabled(plic_irq_id_t irq,
  * @param state The toggle state of the interrupt, as read from the IE registers
  * @return The result of the operation
 */
-plic_result_t plic_irq_get_enabled(plic_irq_id_t irq,
+plic_result_t plic_irq_get_enabled(uint32_t irq,
                                        plic_toggle_t *state);
 
 /**
@@ -328,7 +314,7 @@ plic_result_t plic_irq_get_enabled(plic_irq_id_t irq,
  * @result The result of the operation
  * 
 */
-plic_result_t plic_irq_set_trigger(plic_irq_id_t irq,
+plic_result_t plic_irq_set_trigger(uint32_t irq,
                                            plic_irq_trigger_t trigger);
 
 /**
@@ -338,7 +324,7 @@ plic_result_t plic_irq_set_trigger(plic_irq_id_t irq,
  * @param priority A priority value to set
  * @return The result of the operation
 */
-plic_result_t plic_irq_set_priority(plic_irq_id_t irq, uint32_t priority);
+plic_result_t plic_irq_set_priority(uint32_t irq, uint32_t priority);
 
 /**
  * Sets the priority threshold.
@@ -358,7 +344,7 @@ plic_result_t plic_target_set_threshold(uint32_t threshold);
  * @param irq An interrupt source identification
  * @param[out] is_pending Boolean flagcorresponding to whether an interrupt is pending or not 
 */
-plic_result_t plic_irq_is_pending(plic_irq_id_t irq,
+plic_result_t plic_irq_is_pending(uint32_t irq,
                                           bool *is_pending);
 
 /**
@@ -381,7 +367,7 @@ plic_result_t plic_irq_is_pending(plic_irq_id_t irq,
  * @param[out] claim_data Data that describes the origin of the IRQ.
  * @return The result of the operation.
  */
-plic_result_t plic_irq_claim(plic_irq_id_t *claim_data);
+plic_result_t plic_irq_claim(uint32_t *claim_data);
 
 /**
  * Completes the claimed interrupt request.
@@ -397,7 +383,7 @@ plic_result_t plic_irq_claim(plic_irq_id_t *claim_data);
  * PLIC of the IRQ servicing completion.
  * @return The result of the operation
 */
-plic_result_t plic_irq_complete(const plic_irq_id_t *complete_data);
+plic_result_t plic_irq_complete(const uint32_t *complete_data);
 
 
 /**


### PR DESCRIPTION
Because some interrupt handlers need to know what the source of the interrupt was, all handlers needed to take a parameter with the interrupt ID. 
That was added and changed were necessary. 

This was of interest to @StMiky 
@StefanoAlbini96 could you review? 