### PR TITLE
call cmake3 if available

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -64,6 +64,12 @@ LINK_FOLDER                = $(mkfile_path)/linker
 # CMake keyword
 CMAKE_DIR=cmake
 
+ifeq (, $(shell which cmake3)) # cmake3 is not defined
+CMAKE=cmake
+else
+CMAKE=cmake3
+endif
+
 # Let's CMake!
 include cmake/targets.mak
 

--- a/sw/cmake/targets.mak
+++ b/sw/cmake/targets.mak
@@ -24,7 +24,7 @@ setup : build/Makefile
 build/Makefile : CMakeLists.txt ${CMAKE_DIR}/riscv.cmake
 	if [ ! -d build ] ; then mkdir build ; fi
 	cd build;  \
-		cmake \
+		${CMAKE} \
 		    -G "Unix Makefiles" \
 			-DCMAKE_TOOLCHAIN_FILE=../${CMAKE_DIR}/riscv.cmake \
 			-DROOT_PROJECT=${ROOT_PROJECT} \


### PR DESCRIPTION
In systems where CMake version 3 is available as `cmake3` and there is CMake version 2 as `cmake`, the `cmake_minimum_required(VERSION 3.15)` check on `CMakeLists.txt` will raise a compilation error as it will still take the oldest version.
To avoid this, `cmake3` needs to be explicitly called. Its availability is checked for compatibility with systems where CMake version 3 is still called `cmake` alone. 

An example of a system with CMake version 3 as `cmake` (blue, my local PC with Ubuntu 22.04) and `cmake3` (red, eslsrv12 with CentOS 7.9).  Output from running `make app PROJECT=hello_world` with this branch. 

![image](https://github.com/esl-epfl/x-heep/assets/54960111/6195d39e-16f2-4c4d-acd9-c18964ddb381)
