### PR TITLE
improve the timing of cv32e40x by removing the debug triggers

### DIFF
--- a/hw/core-v-mini-mcu/cpu_subsystem.sv
+++ b/hw/core-v-mini-mcu/cpu_subsystem.sv
@@ -175,7 +175,8 @@ module cpu_subsystem
     // instantiate the core
     cv32e40x_core #(
         .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS),
-        .X_EXT(X_EXT)
+        .X_EXT(X_EXT),
+        .DBG_NUM_TRIGGERS('0)
     ) cv32e40x_core_i (
         // Clock and reset
         .clk_i(clk_i),


### PR DESCRIPTION
This can solve timing violation issues in systems with accelerators attached via the eXtension Interface