### PR TITLE
add soc_ctrl_reg_top warning to verilator waiver

### DIFF
--- a/hw/system/x_heep_system.vlt
+++ b/hw/system/x_heep_system.vlt
@@ -7,3 +7,4 @@
 lint_off -rule UNUSED -file "*/x_heep_system.sv" -match "*"
 lint_off -rule UNDRIVEN -file "*/x_heep_system.sv" -match "*"
 lint_off -rule DECLFILENAME -file "*pad_control_reg_top.sv" -match "Filename 'pad_control_reg_top' does not match MODULE name: 'pad_control_reg_top_intf'*"
+lint_off -rule DECLFILENAME -file "*soc_ctrl_reg_top.sv" -match "Filename 'soc_ctrl_reg_top' does not match MODULE name: 'soc_ctrl_reg_top_intf'*"


### PR DESCRIPTION
Because this module is not named the same way as the containing file its giving a warning when building the simulation with verilator. This warning halts the build.

The warning was added to the `x_heep_system.vlt` to supress the warning. 

