### PR TITLE
Include x-heep.h to all apps that need it

### DIFF
--- a/sw/applications/example_clock_gating/main.c
+++ b/sw/applications/example_clock_gating/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_dma_external/main.c
+++ b/sw/applications/example_dma_external/main.c
@@ -9,7 +9,7 @@
 #include "dma.h"
 #include "core_v_mini_mcu.h"
 #include "csr.h"
-
+#include "x-heep.h"
 
 #define TEST_DATA_SIZE      16
 #define TEST_DATA_LARGE     1024

--- a/sw/applications/example_gpio_toggle/main.c
+++ b/sw/applications/example_gpio_toggle/main.c
@@ -36,22 +36,12 @@ int main(int argc, char *argv[])
     gpio_res = gpio_init(gpio_params, &gpio);
     gpio_res = gpio_output_set_enabled(&gpio, GPIO_TOGGLE, true);
 
-#ifdef TARGET_PYNQ_Z2
-#pragma message ( "this application never ends" )
-    while(1) {
-      gpio_write(&gpio, GPIO_TOGGLE, true);
-      for(int i=0;i<10;i++) asm volatile("nop");
-      gpio_write(&gpio, GPIO_TOGGLE, false);
-      for(int i=0;i<10;i++) asm volatile("nop");
-    }
-#else
     for(int i=0;i<100;i++) {
       gpio_write(&gpio, GPIO_TOGGLE, true);
       for(int i=0;i<10;i++) asm volatile("nop");
       gpio_write(&gpio, GPIO_TOGGLE, false);
       for(int i=0;i<10;i++) asm volatile("nop");
     }
-#endif
 
     PRINTF("Success.\n");
     return EXIT_SUCCESS;

--- a/sw/applications/example_matadd/main.c
+++ b/sw/applications/example_matadd/main.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include "csr.h"
 #include "matrixAdd32.h"
-
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_matfadd/main.c
+++ b/sw/applications/example_matfadd/main.c
@@ -4,9 +4,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "csr.h"
-#include "matrixAdd32.h"
 #include <math.h>
+#include "matrixAdd32.h"
+#include "csr.h"
+#include "x-heep.h"
 
 #define FS_INITIAL 0x01
 

--- a/sw/applications/example_pdm2pcm/main.c
+++ b/sw/applications/example_pdm2pcm/main.c
@@ -20,13 +20,10 @@
 #include <stdlib.h>
 
 #include "core_v_mini_mcu.h"
-#include "pdm2pcm_regs.h"
-
-#include "mmio.h"
-
-#include "groundtruth.h"
-
 #include "x-heep.h"
+#include "pdm2pcm_regs.h"
+#include "mmio.h"
+#include "groundtruth.h"
 
 #ifndef PDM2PCM_IS_INCLUDED
   #error ( "This app does NOT work as the PDM2PCM peripheral is not included" )

--- a/sw/applications/example_power_gating_external/main.c
+++ b/sw/applications/example_power_gating_external/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_power_gating_periph/main.c
+++ b/sw/applications/example_power_gating_periph/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_power_gating_ram_blocks/main.c
+++ b/sw/applications/example_power_gating_ram_blocks/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_set_retentive_ram_blocks/main.c
+++ b/sw/applications/example_set_retentive_ram_blocks/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_set_retentive_ram_blocks_external/main.c
+++ b/sw/applications/example_set_retentive_ram_blocks_external/main.c
@@ -9,6 +9,7 @@
 #include "handler.h"
 #include "core_v_mini_mcu.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 /* Change this value to 0 to disable prints for FPGA and enable them for simulation. */
 #define DEFAULT_PRINTF_BEHAVIOR 1

--- a/sw/applications/example_spi_host/main.c
+++ b/sw/applications/example_spi_host/main.c
@@ -14,6 +14,7 @@
 #include "spi_host.h"
 #include "fast_intr_ctrl.h"
 #include "fast_intr_ctrl_regs.h"
+#include "x-heep.h"
 
 #ifdef TARGET_PYNQ_Z2
     #define USE_SPI_FLASH

--- a/sw/applications/example_spi_host_dma/main.c
+++ b/sw/applications/example_spi_host_dma/main.c
@@ -15,6 +15,7 @@
 #include "dma.h"
 #include "fast_intr_ctrl.h"
 #include "fast_intr_ctrl_regs.h"
+#include "x-heep.h"
 
 #ifdef TARGET_PYNQ_Z2
     #define USE_SPI_FLASH

--- a/sw/applications/example_spi_host_dma_power_gate/main.c
+++ b/sw/applications/example_spi_host_dma_power_gate/main.c
@@ -15,6 +15,7 @@
 #include "dma.h"
 #include "fast_intr_ctrl.h"
 #include "power_manager.h"
+#include "x-heep.h"
 
 #ifdef TARGET_PYNQ_Z2
     #define USE_SPI_FLASH
@@ -323,7 +324,9 @@ int main(int argc, char *argv[])
         PRINTF("success! (bytes checked: %d)\n\r", count*sizeof(*copy_data));
     } else {
         PRINTF("failure, %d errors! (Out of %d)\n\r", errors, count);
+
         return EXIT_FAILURE;
     }
+
     return EXIT_SUCCESS;
 }

--- a/sw/applications/example_virtual_flash/main.c
+++ b/sw/applications/example_virtual_flash/main.c
@@ -16,6 +16,7 @@
 #include "fast_intr_ctrl.h"
 #include "gpio.h"
 #include "fast_intr_ctrl_regs.h"
+#include "x-heep.h"
 
 #define REVERT_24b_ADDR(addr) ((((uint32_t)addr & 0xff0000) >> 16) | ((uint32_t)addr & 0xff00) | (((uint32_t)addr & 0xff) << 16))
 #define FLASH_ADDR 0x00000000


### PR DESCRIPTION
The #ifdefs added to check whether the PRINTF should be declared or not where not working on every app because they did not include the `x-heep.h` file.  It is now included on every app that needs it. 

Additionally i made the `example_gpio_toggle` app finish after 100 toggles in the FPGA as well as the simulation, otherwise it would never finish or print anything while testing with FPGA (requiring a oscilloscope). 

