### PR TITLE
change cv32e40x package manager

### DIFF
--- a/hw/core-v-mini-mcu/include/x-heep_packages.core
+++ b/hw/core-v-mini-mcu/include/x-heep_packages.core
@@ -9,6 +9,8 @@ description: "toplevel packages of x-heep"
 
 filesets:
   files_rtl:
+    depend:
+    - openhwgroup.org:ip:cv32e40x_xif
     files:
     - addr_map_rule_pkg.sv
     - obi_pkg.sv

--- a/hw/vendor/openhwgroup_cv32e40x.core
+++ b/hw/vendor/openhwgroup_cv32e40x.core
@@ -9,10 +9,11 @@ description: "OpenHW Group RISC-V Core CV32E40X"
 
 filesets:
   files_rtl:
+    depend:
+      - openhwgroup.org:ip:cv32e40x_xif
     files:
       - openhwgroup_cv32e40x/rtl/include/cv32e40x_pkg.sv
       - openhwgroup_cv32e40x/rtl/if_c_obi.sv
-      - openhwgroup_cv32e40x/rtl/if_xif.sv
       - openhwgroup_cv32e40x/rtl/cv32e40x_if_stage.sv
       - openhwgroup_cv32e40x/rtl/cv32e40x_csr.sv
       - openhwgroup_cv32e40x/rtl/cv32e40x_debug_triggers.sv

--- a/hw/vendor/openhwgroup_cv32e40x/rtl/if_xif.sv
+++ b/hw/vendor/openhwgroup_cv32e40x/rtl/if_xif.sv
@@ -28,7 +28,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-interface if_xif import cv32e40x_pkg::*;
+interface if_xif
 #(
   parameter int unsigned X_NUM_RS        =  2,  // Number of register file read ports that can be used by the eXtension interface
   parameter int unsigned X_ID_WIDTH      =  4,  // Width of ID field.

--- a/hw/vendor/openhwgroup_cv32e40x_xif.core
+++ b/hw/vendor/openhwgroup_cv32e40x_xif.core
@@ -1,0 +1,19 @@
+CAPI=2:
+
+# Copyright 2021 OpenHW Group
+# Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+name: "openhwgroup.org:ip:cv32e40x_xif"
+description: "OpenHW Group RISC-V Core CV32E40X"
+
+filesets:
+  files_rtl:
+    files:
+      - openhwgroup_cv32e40x/rtl/if_xif.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl


### PR DESCRIPTION
@davidmallasen - can u pls review it? 

Now it is failing the vendor check as I wish to push the modification on the `x_if.sv` file directly on the cv32e40x repo if this works for your 2 systems (Posit and FPU)