### PR TITLE
Make dma_is_ready() non-optimizable

### DIFF
--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -827,7 +827,7 @@ dma_config_flags_t dma_launch( dma_trans_t *p_trans )
 }
 
 
-uint32_t dma_is_ready(void)
+__attribute__((optimize("O0"))) uint32_t dma_is_ready(void)
 {    
     /* The transaction READY bit is read from the status register*/   
     uint32_t ret = ( dma_cb.peri->STATUS & (1<<DMA_STATUS_READY_BIT) );


### PR DESCRIPTION
The function `dm_is_ready()` which reads from a register of the DMA was being optimized, meaning the HAl would never take the CPU to sleep (it always showed as ready). 

We made it non-optimizable to prevent this behavior and always read from the register.