### PR TITLE
fix interleaved bus

### DIFF
--- a/hw/core-v-mini-mcu/memory_subsystem.sv.tpl
+++ b/hw/core-v-mini-mcu/memory_subsystem.sv.tpl
@@ -24,6 +24,9 @@ module memory_subsystem
 
   localparam int NumWords = 32 * 1024 / 4;
   localparam int AddrWidth = $clog2(32 * 1024);
+% if ram_numbanks_il != 0:
+  localparam int ilAddrWidth = $clog2(${ram_numbanks_il} * 32 * 1024);
+% endif
 
   logic [NUM_BANKS-1:0] ram_valid_q;
   // Clock-gating
@@ -33,7 +36,11 @@ module memory_subsystem
 
   for (genvar i = 0; i < NUM_BANKS; i++) begin : gen_addr_napot
     if (i >= NUM_BANKS - ${ram_numbanks_il}) begin
-      assign ram_req_addr[i] = {${log_ram_numbanks_il}'h0, ram_req_i[i].addr[AddrWidth-1:${2+log_ram_numbanks_il}]};
+      assign ram_req_addr[i] = {
+        ram_req_i[i].addr[ilAddrWidth-1:AddrWidth] - 
+        core_v_mini_mcu_pkg::RAM${ram_numbanks_cont}_START_ADDRESS[ilAddrWidth-1:AddrWidth],
+        ram_req_i[i].addr[AddrWidth-1:${2+log_ram_numbanks_il}]
+      };
     end else begin
       assign ram_req_addr[i] = ram_req_i[i].addr[AddrWidth-1:2];
     end

--- a/hw/vendor/patches/pulp_platform_common_cells/addr_decode.patch
+++ b/hw/vendor/patches/pulp_platform_common_cells/addr_decode.patch
@@ -1,0 +1,16 @@
+diff --git a/src/addr_decode.sv b/src/addr_decode.sv
+index e3a8eb2..0456387 100644
+--- a/src/addr_decode.sv
++++ b/src/addr_decode.sv
+@@ -127,8 +127,9 @@ module addr_decode #(
+       $fatal(1, $sformatf("At least one index needed"));
+   end
+ 
+-  assert final ($onehot0(matched_rules)) else
+-    $warning("More than one bit set in the one-hot signal, matched_rules");
++  // Assertion commented to avoid this warning while using the interleaved bus
++  // assert final ($onehot0(matched_rules)) else
++  //   $warning("More than one bit set in the one-hot signal, matched_rules");
+ 
+   // These following assumptions check the validity of the address map.
+   // The assumptions gets generated for each distinct pair of rules.

--- a/hw/vendor/pulp_platform_common_cells.vendor.hjson
+++ b/hw/vendor/pulp_platform_common_cells.vendor.hjson
@@ -10,4 +10,6 @@
     rev: "cf08cc1068e782638185b8316e1ebc0ef90596e7",
   },
 
+  patch_dir: "patches/pulp_platform_common_cells",
+
 }

--- a/hw/vendor/pulp_platform_common_cells/src/addr_decode.sv
+++ b/hw/vendor/pulp_platform_common_cells/src/addr_decode.sv
@@ -127,8 +127,9 @@ module addr_decode #(
       $fatal(1, $sformatf("At least one index needed"));
   end
 
-  assert final ($onehot0(matched_rules)) else
-    $warning("More than one bit set in the one-hot signal, matched_rules");
+  // Assertion commented to avoid this warning while using the interleaved bus
+  // assert final ($onehot0(matched_rules)) else
+  //   $warning("More than one bit set in the one-hot signal, matched_rules");
 
   // These following assumptions check the validity of the address map.
   // The assumptions gets generated for each distinct pair of rules.


### PR DESCRIPTION
The interleaved bus was not using all the address space of the interleaved banks, causing that only 1/2, 1/4 or 1/8 (for 2, 4 and 8 memory interleaved banks respectively) of these banks could be used.

PR contents:
- Fix with a subtraction of 1, 2 or 3 bits (for 2, 4 and 8 memory interleaved banks respectively) to adjust the offset that the continuous banks introduce.
- Patch added to avoid warnings in simulation.