### PR TITLE
adding attributes and mux pad parameters in mcu-gen

### DIFF
--- a/hw/simulation/pad_cell_bypass_input.sv
+++ b/hw/simulation/pad_cell_bypass_input.sv
@@ -4,13 +4,15 @@
 
 /* verilator lint_off UNUSED */
 module pad_cell_bypass_input #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    //do not touch these parameters
+    parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,
     output logic pad_out_o,
     inout logic pad_io,
-    input logic [PADATTR-1:0] pad_attributes_i
+    input logic [PADATTR_RND-1:0] pad_attributes_i
 );
 
   // when ported to another technology, they remain like this

--- a/hw/simulation/pad_cell_bypass_output.sv
+++ b/hw/simulation/pad_cell_bypass_output.sv
@@ -4,13 +4,15 @@
 
 /* verilator lint_off UNUSED */
 module pad_cell_bypass_output #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    //do not touch these parameters
+    parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,
     output logic pad_out_o,
     inout logic pad_io,
-    input logic [PADATTR-1:0] pad_attributes_i
+    input logic [PADATTR_RND-1:0] pad_attributes_i
 );
 
   logic pad;

--- a/hw/simulation/pad_cell_inout.sv
+++ b/hw/simulation/pad_cell_inout.sv
@@ -4,13 +4,15 @@
 
 /* verilator lint_off UNUSED */
 module pad_cell_inout #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    //do not touch these parameters
+    parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,
     output logic pad_out_o,
     inout wire pad_io,
-    input logic [PADATTR-1:0] pad_attributes_i
+    input logic [PADATTR_RND-1:0] pad_attributes_i
 );
 
   logic pad;

--- a/hw/simulation/pad_cell_input.sv
+++ b/hw/simulation/pad_cell_input.sv
@@ -4,13 +4,15 @@
 
 /* verilator lint_off UNUSED */
 module pad_cell_input #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    //do not touch these parameters
+    parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,
     output logic pad_out_o,
     inout wire pad_io,
-    input logic [PADATTR-1:0] pad_attributes_i
+    input logic [PADATTR_RND-1:0] pad_attributes_i
 );
 
   logic pad;

--- a/hw/simulation/pad_cell_output.sv
+++ b/hw/simulation/pad_cell_output.sv
@@ -4,13 +4,15 @@
 
 /* verilator lint_off UNUSED */
 module pad_cell_output #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    //do not touch these parameters
+    parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,
     output logic pad_out_o,
     inout wire pad_io,
-    input logic [PADATTR-1:0] pad_attributes_i
+    input logic [PADATTR_RND-1:0] pad_attributes_i
 );
 
   logic pad;

--- a/hw/system/pad_control/data/pad_control.hjson.tpl
+++ b/hw/system/pad_control/data/pad_control.hjson.tpl
@@ -16,12 +16,13 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits: "3:0", name: "PAD_MUX_${pad.name.upper()}", desc: "Pad Mux ${pad.name.upper()} Reg" }
+        { bits: "${(len(pad.pad_mux_list)-1).bit_length()-1}:0", name: "PAD_MUX_${pad.name.upper()}", desc: "Pad Mux ${pad.name.upper()} Reg" }
       ]
     }
 
 % endfor
 
+% if pads_attributes != None:
 % for pad in total_pad_list:
     { name:     "PAD_ATTRIBUTE_${pad.name.upper()}",
       desc:     "${pad.name} Attributes (Pull Up En, Pull Down En, etc. It is technology specific.",
@@ -29,12 +30,12 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits: "7:0", name: "PAD_ATTRIBUTE_${pad.name.upper()}", desc: "Pad Attribute ${pad.name.upper()} Reg" }
+        { bits: "${pads_attributes['bits']}", name: "PAD_ATTRIBUTE_${pad.name.upper()}", desc: "Pad Attribute ${pad.name.upper()} Reg" }
       ]
     }
 
 % endfor
-
+% endif
 
    ]
 }

--- a/hw/system/pad_control/rtl/pad_control.sv.tpl
+++ b/hw/system/pad_control/rtl/pad_control.sv.tpl
@@ -5,13 +5,29 @@
 module pad_control #(
     parameter type reg_req_t = logic,
     parameter type reg_rsp_t = logic,
+% if not (total_pad_muxed > 0 or pads_attributes != None):
+    /* verilator lint_off UNUSED */
+% endif
     parameter NUM_PAD = 1
 ) (
+
+% if not (total_pad_muxed > 0 or pads_attributes != None):
+    /* verilator lint_off UNUSED */
+% endif
     input logic clk_i,
+% if not (total_pad_muxed > 0 or pads_attributes != None):
+    /* verilator lint_off UNUSED */
+% endif
     input logic rst_ni,
 
     // Bus Interface
+% if not (total_pad_muxed > 0 or pads_attributes != None):
+    /* verilator lint_off UNUSED */
+% endif
     input  reg_req_t reg_req_i,
+% if not (total_pad_muxed > 0 or pads_attributes != None):
+    /* verilator lint_off UNDRIVEN */
+% endif
     output reg_rsp_t reg_rsp_o
 % if total_pad_muxed > 0 or pads_attributes != None:
       ,
@@ -27,6 +43,7 @@ module pad_control #(
 % endif
 );
 
+% if total_pad_muxed > 0 or pads_attributes != None:
 
   import core_v_mini_mcu_pkg::*;
 
@@ -45,6 +62,7 @@ module pad_control #(
       .reg2hw,
       .devmode_i(1'b1)
   );
+% endif
 
 % if pads_attributes != None:
 % for pad in total_pad_list:

--- a/hw/system/pad_control/rtl/pad_control.sv.tpl
+++ b/hw/system/pad_control/rtl/pad_control.sv.tpl
@@ -14,8 +14,10 @@ module pad_control #(
     input  reg_req_t reg_req_i,
     output reg_rsp_t reg_rsp_o,
 
-    output logic [NUM_PAD-1:0][7:0] pad_attributes_o,
-    output logic [NUM_PAD-1:0][3:0] pad_muxes_o
+% if pads_attributes != None:
+    output logic [NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes_o,
+% endif
+    output logic [NUM_PAD-1:0][${max_total_pad_mux_bitlengh-1}:0] pad_muxes_o
 
 );
 
@@ -37,13 +39,15 @@ module pad_control #(
       .devmode_i(1'b1)
   );
 
+% if pads_attributes != None:
 % for pad in total_pad_list:
   assign pad_attributes_o[${pad.localparam}] = reg2hw.pad_attribute_${pad.name.lower()}.q;
 % endfor
+% endif
 
 
 % for pad in pad_muxed_list:
-  assign pad_muxes_o[${pad.localparam}] = reg2hw.pad_mux_${pad.name.lower()}.q;
+  assign pad_muxes_o[${pad.localparam}] = $unsigned(reg2hw.pad_mux_${pad.name.lower()}.q);
 % endfor
 
 endmodule : pad_control

--- a/hw/system/pad_control/rtl/pad_control.sv.tpl
+++ b/hw/system/pad_control/rtl/pad_control.sv.tpl
@@ -12,14 +12,21 @@ module pad_control #(
 
     // Bus Interface
     input  reg_req_t reg_req_i,
-    output reg_rsp_t reg_rsp_o,
-
-% if pads_attributes != None:
-    output logic [NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes_o,
+    output reg_rsp_t reg_rsp_o
+% if total_pad_muxed > 0 or pads_attributes != None:
+      ,
 % endif
+% if pads_attributes != None:
+    output logic [NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes_o
+% if total_pad_muxed > 0:
+      ,
+% endif
+% endif
+% if total_pad_muxed > 0:
     output logic [NUM_PAD-1:0][${max_total_pad_mux_bitlengh-1}:0] pad_muxes_o
-
+% endif
 );
+
 
   import core_v_mini_mcu_pkg::*;
 

--- a/hw/system/pad_ring.sv.tpl
+++ b/hw/system/pad_ring.sv.tpl
@@ -13,7 +13,14 @@ ${external_pad.pad_ring_io_interface}
 ${external_pad.pad_ring_ctrl_interface}
 % endfor
 
-    input logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][7:0] pad_attributes_i
+% if pads_attributes != None:
+    input logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes_i
+% else:
+    // here just for simplicity
+    /* verilator lint_off UNUSED */
+    input logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][0:0] pad_attributes_i
+% endif
+
 );
 
 % for pad in pad_list:

--- a/hw/system/x_heep_system.sv.tpl
+++ b/hw/system/x_heep_system.sv.tpl
@@ -82,7 +82,9 @@ ${pad.x_heep_system_interface}
 % if pads_attributes != None:
   logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes;
 % endif
+ % if total_pad_muxed > 0:
   logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][${max_total_pad_mux_bitlengh-1}:0] pad_muxes;
+% endif
 
   logic rst_ngen;
 
@@ -165,11 +167,19 @@ ${pad_mux_process}
       .clk_i(clk_in_x),
       .rst_ni(rst_ngen),
       .reg_req_i(pad_req),
-      .reg_rsp_o(pad_resp),
-% if pads_attributes != None:
-      .pad_attributes_o(pad_attributes),
+      .reg_rsp_o(pad_resp)
+% if total_pad_muxed > 0 or pads_attributes != None:
+      ,
 % endif
+% if pads_attributes != None:
+      .pad_attributes_o(pad_attributes)
+% if total_pad_muxed > 0:
+      ,
+% endif
+% endif
+% if total_pad_muxed > 0:
       .pad_muxes_o(pad_muxes)
+% endif
   );
 
   rstgen rstgen_i (

--- a/hw/system/x_heep_system.sv.tpl
+++ b/hw/system/x_heep_system.sv.tpl
@@ -79,8 +79,10 @@ ${pad.x_heep_system_interface}
   // PAD controller
   reg_req_t pad_req;
   reg_rsp_t pad_resp;
-  logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][7:0] pad_attributes;
-  logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][3:0] pad_muxes;
+% if pads_attributes != None:
+  logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][${pads_attributes['bits']}] pad_attributes;
+% endif
+  logic [core_v_mini_mcu_pkg::NUM_PAD-1:0][${max_total_pad_mux_bitlengh-1}:0] pad_muxes;
 
   logic rst_ngen;
 
@@ -144,7 +146,11 @@ ${pad.core_v_mini_mcu_bonding}
 % for pad in total_pad_list:
 ${pad.pad_ring_bonding_bonding}
 % endfor
+% if pads_attributes != None:
     .pad_attributes_i(pad_attributes)
+% else:
+    .pad_attributes_i('0)
+% endif
   );
 
 ${pad_constant_driver_assign}
@@ -160,7 +166,9 @@ ${pad_mux_process}
       .rst_ni(rst_ngen),
       .reg_req_i(pad_req),
       .reg_rsp_o(pad_resp),
+% if pads_attributes != None:
       .pad_attributes_o(pad_attributes),
+% endif
       .pad_muxes_o(pad_muxes)
   );
 

--- a/pad_cfg.hjson
+++ b/pad_cfg.hjson
@@ -11,10 +11,6 @@
 
 {
 
-    attributes: {
-        bits: 7:0
-    },
-
     pads: {
 
         clk: {

--- a/pad_cfg.hjson
+++ b/pad_cfg.hjson
@@ -3,7 +3,18 @@
 // SPDX-License-Identifier: SHL-0.51
 // Derived from Occamy: https://github.com/pulp-platform/snitch/blob/master/hw/system/occamy/src/occamy_cfg.hjson
 // Peripherals configuration for core-v-mini-mcu.
+
+// Add this field at the same level of pads (not inside) if you want to define PADs attributes
+//    attributes: {
+//        bits: 7:0
+//    },
+
 {
+
+    attributes: {
+        bits: 7:0
+    },
+
     pads: {
 
         clk: {

--- a/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
+++ b/sw/device/lib/runtime/core_v_mini_mcu.h.tpl
@@ -56,9 +56,11 @@ extern "C" {
 #define ${key.upper()} ${value}
 % endfor
 
+% if pads_attributes != None:
 % for pad in pad_list:
 #define ${pad.localparam}_ATTRIBUTE ${pad.index}
 % endfor
+% endif
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -35,37 +35,41 @@ class Pad:
         self.pad_ring_io_interface = '    inout wire ' + self.io_interface + ','
         self.pad_ring_ctrl_interface += '    output logic ' + self.signal_name + 'o,'
         self.pad_ring_instance = \
-            'pad_cell_input #(.PADATTR(8)) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_input #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(1\'b0),\n' + \
             '   .pad_oe_i(1\'b0),\n' + \
             '   .pad_out_o(' + self.signal_name + 'o),\n' + \
-            '   .pad_io(' + self.signal_name + 'io),\n' + \
-            '   .pad_attributes_i(pad_attributes_i[core_v_mini_mcu_pkg::' + self.localparam + '])\n' + \
-            ');\n\n'
+            '   .pad_io(' + self.signal_name + 'io),\n'
     if self.pad_type == 'output':
         self.pad_ring_io_interface = '    inout wire ' + self.io_interface + ','
         self.pad_ring_ctrl_interface += '    input logic ' + self.signal_name + 'i,'
         self.pad_ring_instance = \
-            'pad_cell_output #(.PADATTR(8)) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_output #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(' + self.signal_name + 'i),\n' + \
             '   .pad_oe_i(1\'b1),\n' + \
             '   .pad_out_o(),\n' + \
-            '   .pad_io(' + self.signal_name + 'io),\n' + \
-            '   .pad_attributes_i(pad_attributes_i[core_v_mini_mcu_pkg::' + self.localparam + '])\n' + \
-            ');\n\n'
+            '   .pad_io(' + self.signal_name + 'io),\n'
     if self.pad_type == 'inout':
         self.pad_ring_io_interface = '    inout wire ' + self.io_interface + ','
         self.pad_ring_ctrl_interface += '    input logic ' + self.signal_name + 'i,\n'
         self.pad_ring_ctrl_interface += '    output logic ' + self.signal_name + 'o,\n'
         self.pad_ring_ctrl_interface += '    input logic ' + self.signal_name + 'oe_i,'
         self.pad_ring_instance = \
-            'pad_cell_inout #(.PADATTR(8)) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_inout #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(' + self.signal_name + 'i),\n' + \
             '   .pad_oe_i(' + self.signal_name + 'oe_i),\n' + \
             '   .pad_out_o(' + self.signal_name + 'o),\n' + \
-            '   .pad_io(' + self.signal_name + 'io),\n' + \
+            '   .pad_io(' + self.signal_name + 'io),\n'
+
+    if self.has_attribute:
+        self.pad_ring_instance += \
             '   .pad_attributes_i(pad_attributes_i[core_v_mini_mcu_pkg::' + self.localparam + '])\n' + \
             ');\n\n'
+    else:
+        self.pad_ring_instance += \
+            '   .pad_attributes_i(\'0)' + \
+            ');\n\n'
+
 
   def create_core_v_mini_mcu_ctrl(self):
 
@@ -189,13 +193,14 @@ class Pad:
         self.pad_ring_bonding_bonding += '    .' + self.signal_name + 'oe_i(' + oe_internal_signals + '),'
         self.x_heep_system_interface += '    inout wire ' + self.signal_name + 'io,'
 
-  def __init__(self, name, cell_name, pad_type, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list):
+  def __init__(self, name, cell_name, pad_type, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, has_attribute, attribute_bits):
 
     self.name = name
     self.cell_name = cell_name
     self.index = index
     self.localparam = 'PAD_' + name.upper()
     self.pad_type = pad_type
+    self.pad_mux_list = pad_mux_list
 
     if('low' in pad_active):
         name_active = 'n'
@@ -203,6 +208,9 @@ class Pad:
         name_active = ''
 
     self.signal_name = self.name + '_' + name_active
+
+    self.has_attribute = has_attribute
+    self.attribute_bits = int(attribute_bits.split(":")[0]) - int(attribute_bits.split(":")[1]) + 1
 
     self.signal_name_drive = []
     self.pad_type_drive    = []
@@ -545,6 +553,13 @@ def main():
 
     pads = obj_pad['pads']
 
+    try:
+        pads_attributes = obj_pad['attributes']
+        pads_attributes_bits = pads_attributes['bits']
+    except KeyError:
+        pads_attributes = None
+        pads_attributes_bits = "-1:0"
+
     # Read HJSON description of External Pads
     if args.external_pads != None:
         with args.external_pads as file_external_pads:
@@ -639,13 +654,13 @@ def main():
             except KeyError:
                 pad_skip_declaration_mux = False
 
-            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [])
+            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
             pad_mux_list.append(p)
 
         if pad_num > 1:
             for p in range(pad_num):
                 pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list)
+                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                 if not pad_keep_internal:
                     pad_obj.create_pad_ring()
                 pad_obj.create_core_v_mini_mcu_ctrl()
@@ -664,7 +679,7 @@ def main():
 
         else:
             pad_cell_name = "pad_" + key + "_i"
-            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list)
+            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
             if not pad_keep_internal:
                 pad_obj.create_pad_ring()
             pad_obj.create_core_v_mini_mcu_ctrl()
@@ -745,13 +760,13 @@ def main():
                 except KeyError:
                     pad_skip_declaration_mux = False
 
-                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [])
+                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
                 pad_mux_list.append(p)
 
             if pad_num > 1:
                 for p in range(pad_num):
                     pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration_mux, pad_mux_list)
+                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                     pad_obj.create_pad_ring()
                     pad_obj.create_pad_ring_bonding()
                     pad_obj.create_internal_signals()
@@ -767,7 +782,7 @@ def main():
 
             else:
                 pad_cell_name = "pad_" + key + "_i"
-                pad_obj = Pad(pad_name, pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list)
+                pad_obj = Pad(pad_name, pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                 pad_obj.create_pad_ring()
                 pad_obj.create_pad_ring_bonding()
                 pad_obj.create_internal_signals()
@@ -784,6 +799,12 @@ def main():
     total_pad_list = []
 
     total_pad_list = pad_list + external_pad_list
+
+    max_total_pad_mux_bitlengh = -1
+    for pad in pad_muxed_list:
+        if (len(pad.pad_mux_list)-1).bit_length() > max_total_pad_mux_bitlengh:
+          max_total_pad_mux_bitlengh = (len(pad.pad_mux_list)-1).bit_length()
+
 
     total_pad = pad_index_counter + external_pad_index_counter
 
@@ -835,6 +856,8 @@ def main():
         "pad_mux_process"                  : pad_mux_process,
         "pad_muxed_list"                   : pad_muxed_list,
         "total_pad_muxed"                  : total_pad_muxed,
+        "max_total_pad_mux_bitlengh"       : max_total_pad_mux_bitlengh,
+        "pads_attributes"                  : pads_attributes,
     }
 
     ###########

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -29,6 +29,7 @@ class Pad:
         ### bypass kind of PADs do not have any comma to be removed as they do not define an interface
 
   def create_pad_ring(self):
+
     self.interface = '    inout wire ' + self.name + '_io,\n'
 
     if self.pad_type == 'input':
@@ -61,14 +62,15 @@ class Pad:
             '   .pad_out_o(' + self.signal_name + 'o),\n' + \
             '   .pad_io(' + self.signal_name + 'io),\n'
 
-    if self.has_attribute:
-        self.pad_ring_instance += \
-            '   .pad_attributes_i(pad_attributes_i[core_v_mini_mcu_pkg::' + self.localparam + '])\n' + \
-            ');\n\n'
-    else:
-        self.pad_ring_instance += \
-            '   .pad_attributes_i(\'0)' + \
-            ');\n\n'
+    if self.pad_type == 'input' or self.pad_type == 'output' or self.pad_type == 'inout':
+        if self.has_attribute:
+            self.pad_ring_instance += \
+                '   .pad_attributes_i(pad_attributes_i[core_v_mini_mcu_pkg::' + self.localparam + '])\n' + \
+                ');\n\n'
+        else:
+            self.pad_ring_instance += \
+                '   .pad_attributes_i(\'0)' + \
+                ');\n\n'
 
 
   def create_core_v_mini_mcu_ctrl(self):


### PR DESCRIPTION
With and without pad attributes:

- [x] try questasim
- [x] try vcs
- [x] try verilator (run all apps)
- [x] try heeperator
- [x] try vivado