### PR TITLE
Add check on `exec_ready_i` to `cv32e40x` decode stage

### DIFF
--- a/hw/vendor/openhwgroup_cv32e40x/rtl/cv32e40x_id_stage.sv
+++ b/hw/vendor/openhwgroup_cv32e40x/rtl/cv32e40x_id_stage.sv
@@ -749,7 +749,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       // Also attempt to offload any CSR instruction. The validity of such instructions are only
       // checked in the EX stage.
       // Instructions with deassert_we set to 1 from the controller bypass logic will not be attempted offloaded.
-      assign xif_issue_if.issue_valid     = instr_valid && (illegal_insn || csr_en) &&
+      // Only offload instructions if the EX stage is ready not to miss data from xif_issue.issue_resp
+      assign xif_issue_if.issue_valid     = instr_valid && ex_ready_i &&
+                                            (illegal_insn || csr_en) &&
                                             !(xif_accepted_q || xif_rejected_q || ctrl_byp_i.deassert_we);
 
       // Keep xif_offloading_o high after an offloaded instruction was accepted or rejected to get

--- a/hw/vendor/patches/openhwgroup_cv32e40x/0002-fix-xif-issue-backpressure.patch
+++ b/hw/vendor/patches/openhwgroup_cv32e40x/0002-fix-xif-issue-backpressure.patch
@@ -1,0 +1,15 @@
+diff --git a/rtl/cv32e40x_id_stage.sv b/rtl/cv32e40x_id_stage.sv
+index 1385dfb..11bc457 100644
+--- a/rtl/cv32e40x_id_stage.sv
++++ b/rtl/cv32e40x_id_stage.sv
+@@ -749,7 +749,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
+       // Also attempt to offload any CSR instruction. The validity of such instructions are only
+       // checked in the EX stage.
+       // Instructions with deassert_we set to 1 from the controller bypass logic will not be attempted offloaded.
+-      assign xif_issue_if.issue_valid     = instr_valid && (illegal_insn || csr_en) &&
++      // Only offload instructions if the EX stage is ready not to miss data from xif_issue.issue_resp
++      assign xif_issue_if.issue_valid     = instr_valid && ex_ready_i &&
++                                            (illegal_insn || csr_en) &&
+                                             !(xif_accepted_q || xif_rejected_q || ctrl_byp_i.deassert_we);
+ 
+       // Keep xif_offloading_o high after an offloaded instruction was accepted or rejected to get


### PR DESCRIPTION
## Description
Fix #365 by offloading instructions to a coprocessor only if the execution stage is ready to accept the new instruction. While this is a suboptimal solution, it prevents the ID-EX pipeline register from missing the XIF Issue Interface response from the coprocessor. More details are available in the associated issue.

This change is implemented as a patch to the `cv32e40x` core, while waiting for a better solution from its developers.

## Status
- [x] Test the proposed solution in [NM-Carus](https://eslgit.epfl.ch/blade/nm-carus)