### PR TITLE
Add stack and heap size as parameters to mcu-gen

### DIFF
--- a/mcu_cfg.hjson
+++ b/mcu_cfg.hjson
@@ -27,6 +27,8 @@
                 lenght: whatisleft, #keyword used to calculate the size as: ram.length - code.lenght
             }
         },
+        stack_size: 0x800,
+        heap_size: 0x800,
     }
 
     debug: {

--- a/sw/linker/link.ld.tpl
+++ b/sw/linker/link.ld.tpl
@@ -38,9 +38,9 @@ SECTIONS
   PROVIDE(__boot_address = 0x180);
 
   /* stack and heap related settings */
-  __stack_size = DEFINED(__stack_size) ? __stack_size : 0x800;
+  __stack_size = DEFINED(__stack_size) ? __stack_size : 0x${stack_size};
   PROVIDE(__stack_size = __stack_size);
-  __heap_size = DEFINED(__heap_size) ? __heap_size : 0x800;
+  __heap_size = DEFINED(__heap_size) ? __heap_size : 0x${heap_size};
 
   /* Read-only sections, merged into text segment: */
   PROVIDE (__executable_start = SEGMENT_START("text-segment", 0x10000)); . = SEGMENT_START("text-segment", 0x10000) + SIZEOF_HEADERS;

--- a/sw/linker/link_flash_exec.ld.tpl
+++ b/sw/linker/link_flash_exec.ld.tpl
@@ -17,9 +17,9 @@ SECTIONS {
     PROVIDE(__boot_address = 0x40000180);
 
     /* stack and heap related settings */
-    __stack_size = DEFINED(__stack_size) ? __stack_size : 0x1000;
+    __stack_size = DEFINED(__stack_size) ? __stack_size : 0x${stack_size};
     PROVIDE(__stack_size = __stack_size);
-    __heap_size = DEFINED(__heap_size) ? __heap_size : 0x1000;
+    __heap_size = DEFINED(__heap_size) ? __heap_size : 0x${heap_size};
 
     /* interrupt vectors */
     .vectors (ORIGIN(FLASH)):

--- a/sw/linker/link_flash_load.ld.tpl
+++ b/sw/linker/link_flash_load.ld.tpl
@@ -17,9 +17,9 @@ SECTIONS {
     PROVIDE(__boot_address = 0x180);
 
     /* stack and heap related settings */
-    __stack_size = DEFINED(__stack_size) ? __stack_size : 0x1000;
+    __stack_size = DEFINED(__stack_size) ? __stack_size : 0x${stack_size};
     PROVIDE(__stack_size = __stack_size);
-    __heap_size = DEFINED(__heap_size) ? __heap_size : 0x1000;
+    __heap_size = DEFINED(__heap_size) ? __heap_size : 0x${heap_size};
 
     /* interrupt vectors */
     .vectors (ORIGIN(RAM)):

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -540,8 +540,15 @@ def main():
     linker_onchip_il_start_address = str('{:08X}'.format(int(linker_onchip_data_start_address,16) + int(linker_onchip_data_size_address,16)))
     linker_onchip_il_size_address = str('{:08X}'.format(ram_numbanks_il*32*1024))
 
+    stack_size  = string2int(obj['linker_script']['stack_size'])
+    heap_size  = string2int(obj['linker_script']['heap_size'])
+
     if ((int(linker_onchip_data_size_address,16) + int(linker_onchip_code_size_address,16)) > int(ram_size_address,16)):
         exit("The code and data section must fit in the RAM size, instead they takes " + str(linker_onchip_data_size_address + linker_onchip_code_size_address))
+    
+    if ((int(stack_size,16) + int(heap_size,16)) > int(ram_size_address,16)):
+        exit("The stack and heap section must fit in the RAM size, instead they takes " + str(stack_size + heap_size))
+
 
     plic_used_n_interrupts = len(obj['interrupts']['list'])
     plit_n_interrupts = obj['interrupts']['number']
@@ -847,6 +854,8 @@ def main():
         "linker_onchip_data_size_address"  : linker_onchip_data_size_address,
         "linker_onchip_il_start_address"   : linker_onchip_il_start_address,
         "linker_onchip_il_size_address"    : linker_onchip_il_size_address,
+        "stack_size"                       : stack_size,
+        "heap_size"                        : heap_size,
         "plic_used_n_interrupts"           : plic_used_n_interrupts,
         "plit_n_interrupts"                : plit_n_interrupts,
         "interrupts"                       : interrupts,


### PR DESCRIPTION
## Description
To run bigger applications, it can be useful to configure heap and stack to have a bigger dimension than the default one.
To manually modify the linker script or the template with a different value is inconvenient, so two parameters are added to the linker script template in order to set this value with the mcu_cfg file.

## Proposed solution
`link.ld.tpl` template is modified to read this parameter and `mcu_gen.py` is modified accordingly.
The default `mcu_cfg.hjson` file is modified to guarantee that the default value is the same as before.