### PR TITLE
fix compilation errrors reported by xcelium

### DIFF
--- a/hw/ip/i2s/rtl/i2s_core.sv
+++ b/hw/ip/i2s/rtl/i2s_core.sv
@@ -7,8 +7,8 @@
 // Description: I2s core logic 
 
 module i2s_core #(
-    parameter MaxWordWidth,
-    parameter ClkDividerWidth
+    parameter MaxWordWidth = 32,
+    parameter ClkDividerWidth = 8
 ) (
     input logic clk_i,
     input logic rst_ni,

--- a/hw/ip/i2s/rtl/i2s_ws_gen.sv
+++ b/hw/ip/i2s/rtl/i2s_ws_gen.sv
@@ -10,7 +10,7 @@
 // by Antonio Pullini (pullinia@iis.ee.ethz.ch)
 
 module i2s_ws_gen #(
-    parameter MaxWordWidth,
+    parameter MaxWordWidth = 32,
     localparam int unsigned CounterWidth = $clog2(MaxWordWidth)
 ) (
     input logic sck_i,

--- a/hw/vendor/patches/pulp_platform_common_cells/clk_mux_glitch_free.patch
+++ b/hw/vendor/patches/pulp_platform_common_cells/clk_mux_glitch_free.patch
@@ -1,0 +1,13 @@
+diff --git a/src/clk_mux_glitch_free.sv b/src/clk_mux_glitch_free.sv
+index e0eb5cd..5193742 100644
+--- a/src/clk_mux_glitch_free.sv
++++ b/src/clk_mux_glitch_free.sv
+@@ -191,7 +191,7 @@ endmodule
+ 
+ // Helper Module to generate an N-input clock OR-gate from a tree of tc_clk_or2 cells.
+ module clk_or_tree #(
+-  parameter int unsigned NUM_INPUTS
++  parameter int unsigned NUM_INPUTS = 1
+ ) (
+   input logic [NUM_INPUTS-1:0] clks_i,
+   output logic clk_o

--- a/hw/vendor/patches/yosyshq_picorv32/0003-spiflash-illegal-expression.patch
+++ b/hw/vendor/patches/yosyshq_picorv32/0003-spiflash-illegal-expression.patch
@@ -1,0 +1,14 @@
+diff --git a/picosoc/spiflash.v b/picosoc/spiflash.v
+index 88582b3..55342b5 100644
+--- a/picosoc/spiflash.v
++++ b/picosoc/spiflash.v
+@@ -109,7 +109,7 @@ module spiflash (
+ 
+ 	initial begin
+ 		for (i=0;i<=16*1024*1024;i=i+1)
+-			memory[i] = '0;
++			memory[i] = 8'h00;
+ 		result = $value$plusargs("firmware=%s", firmware_file);
+ 		if (!result)
+ 			firmware_file = "firmware.hex";
+

--- a/hw/vendor/pulp_platform_common_cells/src/clk_mux_glitch_free.sv
+++ b/hw/vendor/pulp_platform_common_cells/src/clk_mux_glitch_free.sv
@@ -191,7 +191,7 @@ endmodule
 
 // Helper Module to generate an N-input clock OR-gate from a tree of tc_clk_or2 cells.
 module clk_or_tree #(
-  parameter int unsigned NUM_INPUTS
+  parameter int unsigned NUM_INPUTS = 1
 ) (
   input logic [NUM_INPUTS-1:0] clks_i,
   output logic clk_o

--- a/hw/vendor/yosyshq_picorv32/picosoc/spiflash.v
+++ b/hw/vendor/yosyshq_picorv32/picosoc/spiflash.v
@@ -109,7 +109,7 @@ module spiflash (
 
 	initial begin
 		for (i=0;i<=16*1024*1024;i=i+1)
-			memory[i] = '0;
+			memory[i] = 8'h00;
 		result = $value$plusargs("firmware=%s", firmware_file);
 		if (!result)
 			firmware_file = "firmware.hex";

--- a/tb/tb_util.svh.tpl
+++ b/tb/tb_util.svh.tpl
@@ -96,7 +96,7 @@ endtask
 
 % for bank in range(ram_numbanks):
 task tb_writetoSram${bank};
-  input integer addr;
+  input int addr;
   input [7:0] val3;
   input [7:0] val2;
   input [7:0] val1;


### PR DESCRIPTION
there are some features that xcelium reports as not supported, others as illegal syntax.
With these updates x-heep successfully compiles rtl and testbench.