### PR TITLE
Remove mabi from clang compilation flow

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -328,7 +328,6 @@ set(CMAKE_C_FLAGS ${COMPILER_LINKER_FLAGS})
 
 if (${COMPILER} MATCHES "clang")
      set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32 \
-                                          -mabi=ilp32 \
                                           --gcc-toolchain=${RISCV} \
                                           --sysroot=${RISCV}/${COMPILER_PREFIX}elf \
                                           -static \


### PR DESCRIPTION
This limits the compilation capabilities when using the clang compiler. More information on this flag can be found here: https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html