### PR TITLE
Remove dependency from `bc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ else
 	MAX_HEX_ADDRESS  := $(shell cat $(FLASHWRITE_FILE) | grep "@" | tail -1 | cut -c2-)
 	MAX_HEX_ADDRESS_DEC := $(shell printf "%d" 0x$(MAX_HEX_ADDRESS))
 	BYTES_AFTER_MAX_HEX_ADDRESS := $(shell tac $(FLASHWRITE_FILE) | awk 'BEGIN {count=0} /@/ {print count; exit} {count++}')
-	FLASHWRITE_BYTES := $(shell echo $(MAX_HEX_ADDRESS_DEC) + $(BYTES_AFTER_MAX_HEX_ADDRESS)*16 | bc)
+	FLASHWRITE_BYTES := $(shell echo $$(( $(MAX_HEX_ADDRESS_DEC) + $(BYTES_AFTER_MAX_HEX_ADDRESS)*16 )))
 endif
 
 # Export variables to sub-makefiles


### PR DESCRIPTION
`bc` is used in the Makefile to perform simple arithmetic.  While this utility is likely to be installed, it makes more sense to just use the shell's native `$((...))` feature.