### PR TITLE
extend mcu gen pads

### DIFF
--- a/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
+++ b/hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
@@ -190,5 +190,11 @@ package core_v_mini_mcu_pkg;
 
   localparam int unsigned NUM_PAD_PORT_SEL_WIDTH = NUM_PAD > 1 ? $clog2(NUM_PAD) : 32'd1;
 
+  typedef enum logic [1:0] {
+    TOP,
+    RIGHT,
+    BOTTOM,
+    LEFT
+  } pad_side_e;
 
 endpackage

--- a/hw/fpga/pad_cell_inout_xilinx.sv
+++ b/hw/fpga/pad_cell_inout_xilinx.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 module pad_cell_inout #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,

--- a/hw/fpga/pad_cell_input_xilinx.sv
+++ b/hw/fpga/pad_cell_input_xilinx.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 module pad_cell_input #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,

--- a/hw/fpga/pad_cell_output_xilinx.sv
+++ b/hw/fpga/pad_cell_output_xilinx.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 module pad_cell_output #(
-    parameter PADATTR = 16
+    parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP
 ) (
     input logic pad_in_i,
     input logic pad_oe_i,

--- a/hw/simulation/pad_cell_inout.sv
+++ b/hw/simulation/pad_cell_inout.sv
@@ -5,6 +5,7 @@
 /* verilator lint_off UNUSED */
 module pad_cell_inout #(
     parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP,
     //do not touch these parameters
     parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (

--- a/hw/simulation/pad_cell_input.sv
+++ b/hw/simulation/pad_cell_input.sv
@@ -5,6 +5,7 @@
 /* verilator lint_off UNUSED */
 module pad_cell_input #(
     parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP,
     //do not touch these parameters
     parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (

--- a/hw/simulation/pad_cell_output.sv
+++ b/hw/simulation/pad_cell_output.sv
@@ -5,6 +5,7 @@
 /* verilator lint_off UNUSED */
 module pad_cell_output #(
     parameter PADATTR = 16,
+    parameter core_v_mini_mcu_pkg::pad_side_e SIDE = core_v_mini_mcu_pkg::TOP,
     //do not touch these parameters
     parameter PADATTR_RND = PADATTR == 0 ? 1 : PADATTR
 ) (

--- a/pad_cfg.hjson
+++ b/pad_cfg.hjson
@@ -2,8 +2,21 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 // Derived from Occamy: https://github.com/pulp-platform/snitch/blob/master/hw/system/occamy/src/occamy_cfg.hjson
-// Peripherals configuration for core-v-mini-mcu.
-
+//
+// Pads configuration for core-v-mini-mcu. Read by mcu_gen.py.
+// 
+// The pads contains the list of all the pads available in the design.
+// Each pad is defined by its name and can have the following attributes:
+//    num: <number> (mandatory) - the number of pads of this type
+//    type: <input|output|inout> (mandatory) - the type of the pad
+//    num_offset: <number> (optional) - the offset to the first pad of this type (default 0)
+//    mapping: <top|right|bottom|left> (optional) - the mapping of the pad in the design. Useful for ASICs (default top)
+//    active: <low|high> (optional) - the active level of the pad (default high)
+//    driven_manually: <True|False> (optional) - the pad is driven manually (default False)
+//    mux: <dict> (optional) - the muxing options for the pad
+//    skip_declaration: <True|False> (optional) - skip the declaration of the pad in the top level (default False)
+//    keep_internal: <True|False> (optional) - keep the pad internal to the design (default False)
+// 
 // Add this field at the same level of pads (not inside) if you want to define PADs attributes
 //    attributes: {
 //        bits: 7:0

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -209,13 +209,14 @@ class Pad:
         self.pad_ring_bonding_bonding += '    .' + self.signal_name + 'oe_i(' + oe_internal_signals + '),'
         self.x_heep_system_interface += '    inout wire ' + self.signal_name + 'io,'
 
-  def __init__(self, name, cell_name, pad_type, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, has_attribute, attribute_bits):
+  def __init__(self, name, cell_name, pad_type, pad_mapping, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, has_attribute, attribute_bits):
 
     self.name = name
     self.cell_name = cell_name
     self.index = index
     self.localparam = 'PAD_' + name.upper()
     self.pad_type = pad_type
+    self.pad_mapping = pad_mapping
     self.pad_mux_list = pad_mux_list
 
     if('low' in pad_active):
@@ -651,7 +652,7 @@ def main():
         if pad_num > 1:
             for p in range(pad_num):
                 pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
+                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                 if not pad_keep_internal:
                     pad_obj.create_pad_ring()
                 pad_obj.create_core_v_mini_mcu_ctrl()
@@ -670,7 +671,7 @@ def main():
 
         else:
             pad_cell_name = "pad_" + key + "_i"
-            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
+            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
             if not pad_keep_internal:
                 pad_obj.create_pad_ring()
             pad_obj.create_core_v_mini_mcu_ctrl()
@@ -704,6 +705,11 @@ def main():
                 pad_active = external_pads[key]['active']
             except KeyError:
                 pad_active = 'high'
+
+            try:
+                pad_mapping = external_pads[key]['mapping']
+            except KeyError:
+                pad_mapping = None
 
             try:
                 pad_mux_list_hjson = external_pads[key]['mux']
@@ -757,7 +763,7 @@ def main():
             if pad_num > 1:
                 for p in range(pad_num):
                     pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
+                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                     pad_obj.create_pad_ring()
                     pad_obj.create_pad_ring_bonding()
                     pad_obj.create_internal_signals()
@@ -773,7 +779,7 @@ def main():
 
             else:
                 pad_cell_name = "pad_" + key + "_i"
-                pad_obj = Pad(pad_name, pad_cell_name, pad_type, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
+                pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits)
                 pad_obj.create_pad_ring()
                 pad_obj.create_pad_ring_bonding()
                 pad_obj.create_internal_signals()

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -646,7 +646,7 @@ def main():
             except KeyError:
                 pad_skip_declaration_mux = False
 
-            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
+            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
             pad_mux_list.append(p)
 
         if pad_num > 1:
@@ -757,7 +757,7 @@ def main():
                 except KeyError:
                     pad_skip_declaration_mux = False
 
-                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
+                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits)
                 pad_mux_list.append(p)
 
             if pad_num > 1:

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -34,10 +34,10 @@ class Pad:
 
     # Mapping dictionary from string to integer
     mapping_dict = {
-        'top' : 0,
-        'right' : 1,
-        'bottom' : 2,
-        'left' : 3
+        'top' : 'core_v_mini_mcu_pkg::TOP',
+        'right' : 'core_v_mini_mcu_pkg::RIGHT',
+        'bottom' : 'core_v_mini_mcu_pkg::BOTTOM',
+        'left' : 'core_v_mini_mcu_pkg::LEFT'
     }
 
     mapping = ''
@@ -575,7 +575,7 @@ def main():
 
         pad_name = key
         pad_num  = pads[key]['num']
-        pad_type = pads[key]['type']
+        pad_type = pads[key]['type'].strip(',')
 
         try:
             pad_offset = int(pads[key]['num_offset'])
@@ -588,7 +588,7 @@ def main():
             pad_active = 'high'
         
         try:
-            pad_mapping = pads[key]['mapping']
+            pad_mapping = pads[key]['mapping'].strip(',')
         except KeyError:
             pad_mapping = None
 

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -32,13 +32,25 @@ class Pad:
 
   def create_pad_ring(self):
 
+    # Mapping dictionary from string to integer
+    mapping_dict = {
+        'top' : 0,
+        'right' : 1,
+        'bottom' : 2,
+        'left' : 3
+    }
+
+    mapping = ''
+    if self.pad_mapping is not None:
+        mapping = ', .SIDE(' + mapping_dict[self.pad_mapping] + ')'
+
     self.interface = '    inout wire ' + self.name + '_io,\n'
 
     if self.pad_type == 'input':
         self.pad_ring_io_interface = '    inout wire ' + self.io_interface + ','
         self.pad_ring_ctrl_interface += '    output logic ' + self.signal_name + 'o,'
         self.pad_ring_instance = \
-            'pad_cell_input #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_input #(.PADATTR('+ str(self.attribute_bits) +')' + mapping + ') ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(1\'b0),\n' + \
             '   .pad_oe_i(1\'b0),\n' + \
             '   .pad_out_o(' + self.signal_name + 'o),\n' + \
@@ -47,7 +59,7 @@ class Pad:
         self.pad_ring_io_interface = '    inout wire ' + self.io_interface + ','
         self.pad_ring_ctrl_interface += '    input logic ' + self.signal_name + 'i,'
         self.pad_ring_instance = \
-            'pad_cell_output #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_output #(.PADATTR('+ str(self.attribute_bits) +')' + mapping + ') ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(' + self.signal_name + 'i),\n' + \
             '   .pad_oe_i(1\'b1),\n' + \
             '   .pad_out_o(),\n' + \
@@ -58,7 +70,7 @@ class Pad:
         self.pad_ring_ctrl_interface += '    output logic ' + self.signal_name + 'o,\n'
         self.pad_ring_ctrl_interface += '    input logic ' + self.signal_name + 'oe_i,'
         self.pad_ring_instance = \
-            'pad_cell_inout #(.PADATTR('+ str(self.attribute_bits) +')) ' + self.cell_name + ' ( \n' + \
+            'pad_cell_inout #(.PADATTR('+ str(self.attribute_bits) +')' + mapping + ') ' + self.cell_name + ' ( \n' + \
             '   .pad_in_i(' + self.signal_name + 'i),\n' + \
             '   .pad_oe_i(' + self.signal_name + 'oe_i),\n' + \
             '   .pad_out_o(' + self.signal_name + 'o),\n' + \
@@ -573,6 +585,11 @@ def main():
             pad_active = pads[key]['active']
         except KeyError:
             pad_active = 'high'
+        
+        try:
+            pad_mapping = pads[key]['mapping']
+        except KeyError:
+            pad_mapping = None
 
         try:
             pad_mux_list_hjson = pads[key]['mux']


### PR DESCRIPTION
Extend the pad configuration so it includes an optional mapping to the side of the die. An example of this extra configuration is as follows:

~~~
module pad_cell_inout #(
    parameter int unsigned PADATTR = 16,
    parameter int unsigned SIDE = 0, // 0: top, 1: right, 2: bottom, 3: left
) (
    input logic pad_in_i,
    input logic pad_oe_i,
    output logic pad_out_o,
    inout logic pad_io,
    input logic [PADATTR-1:0] pad_attributes_i
);
    if (SIDE == 0) begin
        // Instantiate the top mapping pad cell
    end else if (SIDE == 1) begin
        // Instantiate the right mapping pad cell
    end else if
    // ...
endmodule

~~~