### PR TITLE
Add links in the docs to X-HEEP based cryptography projects from PoliTO VLSI Lab

### DIFF
--- a/docs/source/How_to/eXtendingHEEP.md
+++ b/docs/source/How_to/eXtendingHEEP.md
@@ -10,7 +10,7 @@ Here you can find a list of `X-HEEP` based open-source examples. If you want to 
 
 * [CGRA-X-HEEP](https://github.com/esl-epfl/cgra_x_heep): A CGRA loosely coupled with X-HEEP.
 * [F-HEEP](https://github.com/davidmallasen/F-HEEP): System integrating [fpu_ss](https://github.com/pulp-platform/fpu_ss) into X-HEEP via the eXtension interface and cv32e40x.
-* [ANTT-HEEP](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRHEEPT](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak cryptographic functions.
+* [KALIPSO](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRONOS](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak hash function.
 
 
 In addition, the `X-HEEP` testbench has been extended with a `DMA`, dummy `PERIPHERALs` (including the `FLASH`), and a CORE-V-XIF compatible co-processor

--- a/docs/source/How_to/eXtendingHEEP.md
+++ b/docs/source/How_to/eXtendingHEEP.md
@@ -10,6 +10,7 @@ Here you can find a list of `X-HEEP` based open-source examples. If you want to 
 
 * [CGRA-X-HEEP](https://github.com/esl-epfl/cgra_x_heep): A CGRA loosely coupled with X-HEEP.
 * [F-HEEP](https://github.com/davidmallasen/F-HEEP): System integrating [fpu_ss](https://github.com/pulp-platform/fpu_ss) into X-HEEP via the eXtension interface and cv32e40x.
+* [ANTT-HEEP](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRHEEPT](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak cryptographic functions.
 
 
 In addition, the `X-HEEP` testbench has been extended with a `DMA`, dummy `PERIPHERALs` (including the `FLASH`), and a CORE-V-XIF compatible co-processor

--- a/docs/source/How_to/eXtendingHEEP.md
+++ b/docs/source/How_to/eXtendingHEEP.md
@@ -10,7 +10,7 @@ Here you can find a list of `X-HEEP` based open-source examples. If you want to 
 
 * [CGRA-X-HEEP](https://github.com/esl-epfl/cgra_x_heep): A CGRA loosely coupled with X-HEEP.
 * [F-HEEP](https://github.com/davidmallasen/F-HEEP): System integrating [fpu_ss](https://github.com/pulp-platform/fpu_ss) into X-HEEP via the eXtension interface and cv32e40x.
-* [KALIPSO](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRONOS](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak hash function.
+* [KALIPSO](https://github.com/vlsi-lab/ntt_intt_kyber) and [KRONOS](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): Loosely-coupled, post-quantum cryptography accelerators for NTT/INTT and Keccak hash function integrated into X-HEEP.
 
 
 In addition, the `X-HEEP` testbench has been extended with a `DMA`, dummy `PERIPHERALs` (including the `FLASH`), and a CORE-V-XIF compatible co-processor


### PR DESCRIPTION
## Description
Add links to X-HEEP based projects by @aledolme from Politecnico di Torino (DET - VLSI Lab) to the existing list of open-source projects in the _eXtend X-HEEP_ section of the documentation. In particular, the following projects are listed:
- [KALIPSO](https://github.com/vlsi-lab/ntt_intt_kyber): X-HEEP system with a loosely-coupled accelerator for NTT/INTT polynomial-multiplication in the context of post-quantum cryptography algorithms.
- [KRONOS](https://github.com/vlsi-lab/keccak_integration/tree/keccak_xheep): X-HEEP system with a loosely-coupled accelerator for the Keccak hash function.