### PR TITLE
Make the Makefile help extendible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ mkfile_path := $(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
 $(info $$You are executing from: $(mkfile_path))
 
 # Include the self-documenting tool
-FILE=$(mkfile_path)/Makefile
-include $(mkfile_path)/util/generate-makefile-help
+export FILE_FOR_HELP=$(mkfile_path)/Makefile
+
+help:
+	${mkfile_path}/util/MakefileHelp
 
 # Setup to autogenerate python virtual environment
 VENVDIR?=$(WORKDIR)/.venv

--- a/docs/source/How_to/eXtendingHEEP.md
+++ b/docs/source/How_to/eXtendingHEEP.md
@@ -304,7 +304,7 @@ To do so, it MUST include the `external.mk` AFTER all your custom rules.
 <details>
     <summary>Example of BASE/Makefile</summary>
 
-```
+```Makefile
 MAKE     = make
 .PHONY: test
 test:
@@ -326,11 +326,50 @@ include $(XHEEP_MAKE)
 * The `app` rule will perform actions before calling `X-HEEP` Makefile's `app` rule. In this case, the project and where the source files are to be extracted from is being specified. The `SOURCE=.` argument will set `X-HEEP`'s own `sw/` folder as the directory from which to fetch source files. This is an example of building inner sources from an external directory.
 * The `verilator-sim` rule will override the `X-HEEP` Makefile's one.
 * Any other target will be passed straight to `X-HEEP`'s Makefile. For example
-```
+```sh
 make mcu-gen CPU=cv32e40x
 ```
 </details>
 
+
+### Makefile help
+If you want that the commands `make` or `make help` show the help for your external Makefile, add the following lines before the first `include` directive or target.
+
+<details>
+    <summary>Addition to print the target's help</summary>
+
+```Makefile
+# HEEP_DIR might already be defined, you may want to move it to the top
+export HEEP_DIR = hw/vendor/esl_epfl_x_heep/
+
+# Get the path of this Makefile to pass to the Makefile help generator
+MKFILE_PATH = $(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
+export FILE_FOR_HELP = $(MKFILE_PATH)/Makefile
+
+
+## Call the help generator. Calling simply
+## $ make
+## or
+## $ make help
+## Will print the help of this project.
+## With the parameter WHICH you can select to print
+## either the help of X-HEEP (WHICH=xheep)
+## or both this project's and X-HEEP's (WHICH=all)
+help:
+ifndef WHICH
+	${HEEP_DIR}/util/MakefileHelp
+else ifeq ($(filter $(WHICH),xheep x-heep),)
+	${HEEP_DIR}/util/MakefileHelp
+	$(MAKE) -C $(HEEP_DIR) help
+else
+	$(MAKE) -C $(HEEP_DIR) help
+endif
+```
+
+</details>
+
+> Remeber to add double hashes `##` on any comment you want printed on the help.
+> Use `## @section SectionName` to divide the documentation in sections
 
 ### Different use cases
 If you plan to vendorize `X-HEEP` in a different directory than the one proposed, just update in your `BASE/Makefile`:

--- a/util/MakefileHelp
+++ b/util/MakefileHelp
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-FILE=Makefile
 RULE_COLOR="$(tput setaf 6)"
 SECTION_COLOR="$(tput setaf 3)"
 VARIABLE_COLOR="$(tput setaf 2)"
@@ -23,7 +21,7 @@ PARAM_REGEX="@param\s+([a-zA-Z_]+)(=([^\s]+))?\s*(.*$)?"
 COMMENT=""
 PARAMS=""
 PARAMS_DOC=""
-cat $FILE | while read line
+cat $FILE_FOR_HELP | while read line
 do
     # do something with $line here
     if [[ ! -z $line ]]

--- a/util/generate-makefile-help
+++ b/util/generate-makefile-help
@@ -1,2 +1,0 @@
-help:
-	util/MakefileHelp


### PR DESCRIPTION
To allow projects vendorizing X-HEEP to use the Makefile target documentation generation (what is printed when you run only `make`) I needed to make a small change in the Makefile. 

I also removed an unnecessary intermediate file and updated the documentation so we can replicate this on all other projects. 

I tested this [on a HEEPsilon branch](https://github.com/JuanSapriza/HEEPsilon/tree/makefile_automatic_generation).   