### PR TITLE
Edit variable declaration in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,22 +64,22 @@ FLASHREAD_ADDR ?= 0x0
 FLASHREAD_FILE ?= $(mkfile_path)/flashcontent.hex
 FLASHREAD_BYTES ?= 256
 
-#max address in the hex file, used to program the flash
-ifeq ($(wildcard sw/build/main.hex),)
-	MAX_HEX_ADDRESS  = 0
-	MAX_HEX_ADDRESS_DEC = 0
-	BYTES_AFTER_MAX_HEX_ADDRESS = 0
-	FLASHRWITE_BYTES = 0
-else
-	MAX_HEX_ADDRESS  = $(shell cat sw/build/main.hex | grep "@" | tail -1 | cut -c2-)
-	MAX_HEX_ADDRESS_DEC = $(shell printf "%d" 0x$(MAX_HEX_ADDRESS))
-	BYTES_AFTER_MAX_HEX_ADDRESS = $(shell tac sw/build/main.hex | awk 'BEGIN {count=0} /@/ {print count; exit} {count++}')
-	FLASHRWITE_BYTES = $(shell echo $(MAX_HEX_ADDRESS_DEC) + $(BYTES_AFTER_MAX_HEX_ADDRESS)*16 | bc)
-endif
-
 
 #binary to store in flash memory
 FLASHWRITE_FILE = $(mkfile_path)/sw/build/main.hex
+
+#max address in the hex file, used to program the flash
+ifeq ($(wildcard $(FLASHWRITE_FILE)),)
+	MAX_HEX_ADDRESS  := 0
+	MAX_HEX_ADDRESS_DEC := 0
+	BYTES_AFTER_MAX_HEX_ADDRESS := 0
+	FLASHWRITE_BYTES := 0
+else
+	MAX_HEX_ADDRESS  := $(shell cat $(FLASHWRITE_FILE) | grep "@" | tail -1 | cut -c2-)
+	MAX_HEX_ADDRESS_DEC := $(shell printf "%d" 0x$(MAX_HEX_ADDRESS))
+	BYTES_AFTER_MAX_HEX_ADDRESS := $(shell tac $(FLASHWRITE_FILE) | awk 'BEGIN {count=0} /@/ {print count; exit} {count++}')
+	FLASHWRITE_BYTES := $(shell echo $(MAX_HEX_ADDRESS_DEC) + $(BYTES_AFTER_MAX_HEX_ADDRESS)*16 | bc)
+endif
 
 # Export variables to sub-makefiles
 export
@@ -260,7 +260,7 @@ flash-readid:
 ## Loads the obtained binary to the EPFL_Programmer flash
 flash-prog:
 	cd sw/vendor/yosyshq_icestorm/iceprog; make; \
-	./iceprog -a $(FLASHRWITE_BYTES) -d i:0x0403:0x6011 -I B $(FLASHWRITE_FILE);
+	./iceprog -a $(FLASHWRITE_BYTES) -d i:0x0403:0x6011 -I B $(FLASHWRITE_FILE);
 
 ## Read the EPFL_Programmer flash
 flash-read:


### PR DESCRIPTION
When running targets that use the `MAX_HEX_ADDRESS`, `MAX_HEX_ADDRESS_DEC`, `BYTES_AFTER_MAX_HEX_ADDRESS` and `FLASHWRITE_BYTES` variables of the makefile some faulty output is generated:

```bash
/bin/sh: line 1: printf: 0x: invalid hex number
/bin/sh: line 1: printf: 0x: invalid hex number
/bin/sh: line 1: printf: 0x: invalid hex number
/bin/sh: line 1: printf: 0x: invalid hex number
```
Since these variables are defined with the `=` they are evaluated at run time and for some strange reason are not evaluated correctly.

Defining these variables with `:=`, so being evaluated at declaration time, seems to solve this issue.

Noticed a type in the name of one of the variable too, I fixed this too.

:warning: :warning: :warning: :warning: :warning: :warning:  
This can be something related to my specific system configuration, so the solution can be different on a different system.
So, please, someone with a different configuration can doublecheck that this is working? (@JuanSapriza 
 @JoseCalero :pray: )

Steps to reproduce and check if everything is fine:
```bash
make app
make flash-prog
```

It is not necessary to connect the programmer to the computer, since it is not relevant what iceprog thinks.
