### PR TITLE
Fix example_gpio_intr

### DIFF
--- a/sw/applications/example_gpio_intr/main.c
+++ b/sw/applications/example_gpio_intr/main.c
@@ -150,6 +150,7 @@ int main(int argc, char *argv[])
         // wait_for_interrupt();
         CSR_SET_BITS(CSR_REG_MSTATUS, 0x8);
     }
+    gpio_res = gpio_write(GPIO_TB_OUT, false);
 
     gpio_assign_irq_handler( GPIO_INTR, &handler_2 );
     gpio_intr_flag = 0;


### PR DESCRIPTION
ensure the counter can restart

If we do not do this the application freezes because the counter never resets.