### PR TITLE
fix zcu104 flash 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,11 @@ flash-read:
 	cd sw/vendor/yosyshq_icestorm/iceprog; make; \
 	./iceprog -d i:0x0403:0x6011 -I B -o $(shell printf "%d" $(FLASHREAD_ADDR)) -R $(FLASHREAD_BYTES) $(FLASHREAD_FILE);
 
+## Erase the EPFL_Programmer flash
+flash-erase:
+	cd sw/vendor/yosyshq_icestorm/iceprog; make; \
+	./iceprog -d i:0x0403:0x6011 -I B -b;
+
 ## Run openOCD w/ EPFL_Programmer
 openOCD_epflp:
 	xterm -e openocd -f ./tb/core-v-mini-mcu-pynq-z2-esl-programmer.cfg;

--- a/sw/applications/coremark/coremark.h
+++ b/sw/applications/coremark/coremark.h
@@ -64,7 +64,7 @@ Original Author: Shay Gal-on
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define ee_printf(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define ee_printf(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define ee_printf printf

--- a/sw/applications/example_clock_gating/main.c
+++ b/sw/applications/example_clock_gating/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_dma/main.c
+++ b/sw/applications/example_dma/main.c
@@ -35,7 +35,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_dma_external/main.c
+++ b/sw/applications/example_dma_external/main.c
@@ -20,7 +20,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_gpio_intr/main.c
+++ b/sw/applications/example_gpio_intr/main.c
@@ -29,7 +29,7 @@ Notes:
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_gpio_toggle/main.c
+++ b/sw/applications/example_gpio_toggle/main.c
@@ -16,7 +16,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_i2s/main.c
+++ b/sw/applications/example_i2s/main.c
@@ -72,7 +72,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_iffifo/main.c
+++ b/sw/applications/example_iffifo/main.c
@@ -32,7 +32,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_im2col/im2col_lib.h
+++ b/sw/applications/example_im2col/im2col_lib.h
@@ -33,7 +33,7 @@
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
     #define PRINTF_DEB(...) 
     #define PRINTF_TIM(...)   
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
     #if DEBUG
         #define PRINTF_DEB(fmt, ...)    printf(fmt, ## __VA_ARGS__)

--- a/sw/applications/example_matadd/main.c
+++ b/sw/applications/example_matadd/main.c
@@ -14,7 +14,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_matadd_interleaved/main.c
+++ b/sw/applications/example_matadd_interleaved/main.c
@@ -15,7 +15,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_matfadd/main.c
+++ b/sw/applications/example_matfadd/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_matmul/main.c
+++ b/sw/applications/example_matmul/main.c
@@ -14,7 +14,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_pdm2pcm/main.c
+++ b/sw/applications/example_pdm2pcm/main.c
@@ -35,7 +35,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_power_gating_core/main.c
+++ b/sw/applications/example_power_gating_core/main.c
@@ -30,7 +30,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_power_gating_external/main.c
+++ b/sw/applications/example_power_gating_external/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_power_gating_periph/main.c
+++ b/sw/applications/example_power_gating_periph/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_power_gating_ram_blocks/main.c
+++ b/sw/applications/example_power_gating_ram_blocks/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_set_retentive_ram_blocks/main.c
+++ b/sw/applications/example_set_retentive_ram_blocks/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_set_retentive_ram_blocks_external/main.c
+++ b/sw/applications/example_set_retentive_ram_blocks_external/main.c
@@ -17,7 +17,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_spi_host_dma_power_gate/main.c
+++ b/sw/applications/example_spi_host_dma_power_gate/main.c
@@ -27,7 +27,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_spi_read/main.c
+++ b/sw/applications/example_spi_read/main.c
@@ -26,7 +26,7 @@
     #define PRINTF(...)
 #endif
 
-#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
     #define USE_SPI_FLASH
 #endif
 

--- a/sw/applications/example_spi_read/main.c
+++ b/sw/applications/example_spi_read/main.c
@@ -20,7 +20,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104) && PRINTF_IN_FPGA
+#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104 || TARGET_NEXYS_A7_100T) && PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_spi_read/main.c
+++ b/sw/applications/example_spi_read/main.c
@@ -20,7 +20,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104 || TARGET_NEXYS_A7_100T) && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_spi_read/main.c
+++ b/sw/applications/example_spi_read/main.c
@@ -20,13 +20,13 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104) && PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)
 #endif
 
-#ifdef TARGET_PYNQ_Z2
+#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
     #define USE_SPI_FLASH
 #endif
 

--- a/sw/applications/example_spi_write/main.c
+++ b/sw/applications/example_spi_write/main.c
@@ -25,13 +25,13 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104) && PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)
 #endif
 
-#ifdef TARGET_PYNQ_Z2
+#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
     #define USE_SPI_FLASH
 #endif
 

--- a/sw/applications/example_spi_write/main.c
+++ b/sw/applications/example_spi_write/main.c
@@ -31,7 +31,7 @@
     #define PRINTF(...)
 #endif
 
-#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+#if defined(TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
     #define USE_SPI_FLASH
 #endif
 

--- a/sw/applications/example_spi_write/main.c
+++ b/sw/applications/example_spi_write/main.c
@@ -25,7 +25,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104) && PRINTF_IN_FPGA
+#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104 || TARGET_NEXYS_A7_100T) && PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/example_spi_write/main.c
+++ b/sw/applications/example_spi_write/main.c
@@ -25,7 +25,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif (TARGET_PYNQ_Z2 || TARGET_ZCU104 || TARGET_NEXYS_A7_100T) && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/applications/minver/chipsupport.c
+++ b/sw/applications/minver/chipsupport.c
@@ -31,7 +31,7 @@
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
-#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+#elif PRINTF_IN_FPGA
     #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
 #else
     #define PRINTF(...)

--- a/sw/device/bsp/w25q/w25q.c
+++ b/sw/device/bsp/w25q/w25q.c
@@ -72,7 +72,7 @@
 /**
  * @bref If the target is the FPGA, use the SPI FLASH.
 */
-#if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+#ifndef TARGET_SIM
 #define USE_SPI_FLASH
 #endif
 
@@ -268,9 +268,9 @@ w25q_error_codes_t w25q128jw_init(spi_host_t spi_host) {
     flash_power_up();
 
     // Set QE bit (only FPGA, simulation do not support status registers at all)
-    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+    #ifndef TARGET_SIM
     if (set_QE_bit() == FLASH_ERROR) return FLASH_ERROR; // Error occurred while setting QE bit
-    #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+    #endif // TARGET_SIM
 
     return FLASH_OK; // Success
 }
@@ -410,9 +410,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard(uint32_t addr, void* data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+        #endif // TARGET_SIM
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -551,9 +551,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard_dma(uint32_t addr, void* d
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+        #endif // TARGET_SIM
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -609,7 +609,7 @@ w25q_error_codes_t w25q128jw_read_quad(uint32_t addr, void *data, uint32_t lengt
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1,
         #else
         .len        = DUMMY_CLOCKS_SIM-1,
@@ -699,9 +699,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad(uint32_t addr, void *data, uin
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+        #endif // TARGET_SIM
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -757,7 +757,7 @@ w25q_error_codes_t w25q128jw_read_quad_dma(uint32_t addr, void *data, uint32_t l
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1, // W25Q128JW flash needs 4 dummy cycles
         #else
         .len        = DUMMY_CLOCKS_SIM-1, // SPI flash simulation model needs 8 dummy cycles
@@ -865,9 +865,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void *data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+        #endif // TARGET_SIM
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -1220,9 +1220,9 @@ w25q_error_codes_t erase_and_write(uint32_t addr, uint8_t *data, uint32_t length
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+        #ifndef TARGET_SIM
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+        #endif // TARGET_SIM
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -1344,9 +1344,9 @@ static w25q_error_codes_t page_write(uint32_t addr, uint8_t *data, uint32_t leng
     spi_wait_for_ready(&spi);
 
     // Wait for flash to be ready again (FPGA only)
-    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
+    #ifndef TARGET_SIM
     flash_wait();
-    #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
+    #endif // TARGET_SIM
 }
 
 static w25q_error_codes_t dma_send_toflash(uint8_t *data, uint32_t length) {

--- a/sw/device/bsp/w25q/w25q.c
+++ b/sw/device/bsp/w25q/w25q.c
@@ -72,7 +72,7 @@
 /**
  * @bref If the target is the FPGA, use the SPI FLASH.
 */
-#if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+#if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
 #define USE_SPI_FLASH
 #endif
 
@@ -268,7 +268,7 @@ w25q_error_codes_t w25q128jw_init(spi_host_t spi_host) {
     flash_power_up();
 
     // Set QE bit (only FPGA, simulation do not support status registers at all)
-    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
     if (set_QE_bit() == FLASH_ERROR) return FLASH_ERROR; // Error occurred while setting QE bit
     #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -410,7 +410,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard(uint32_t addr, void* data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         w25q128jw_4k_erase(sector_start_addr);
         #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -551,7 +551,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard_dma(uint32_t addr, void* d
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         w25q128jw_4k_erase(sector_start_addr);
         #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -609,7 +609,7 @@ w25q_error_codes_t w25q128jw_read_quad(uint32_t addr, void *data, uint32_t lengt
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1,
         #else
         .len        = DUMMY_CLOCKS_SIM-1,
@@ -699,7 +699,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad(uint32_t addr, void *data, uin
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         w25q128jw_4k_erase(sector_start_addr);
         #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -757,7 +757,7 @@ w25q_error_codes_t w25q128jw_read_quad_dma(uint32_t addr, void *data, uint32_t l
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1, // W25Q128JW flash needs 4 dummy cycles
         #else
         .len        = DUMMY_CLOCKS_SIM-1, // SPI flash simulation model needs 8 dummy cycles
@@ -865,7 +865,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void *data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         w25q128jw_4k_erase(sector_start_addr);
         #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -1220,7 +1220,7 @@ w25q_error_codes_t erase_and_write(uint32_t addr, uint8_t *data, uint32_t length
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
         w25q128jw_4k_erase(sector_start_addr);
         #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
@@ -1344,7 +1344,7 @@ static w25q_error_codes_t page_write(uint32_t addr, uint8_t *data, uint32_t leng
     spi_wait_for_ready(&spi);
 
     // Wait for flash to be ready again (FPGA only)
-    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
+    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104) || defined(TARGET_NEXYS_A7_100T)
     flash_wait();
     #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 }

--- a/sw/device/bsp/w25q/w25q.c
+++ b/sw/device/bsp/w25q/w25q.c
@@ -72,7 +72,7 @@
 /**
  * @bref If the target is the FPGA, use the SPI FLASH.
 */
-#ifdef TARGET_PYNQ_Z2
+#if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
 #define USE_SPI_FLASH
 #endif
 
@@ -268,9 +268,9 @@ w25q_error_codes_t w25q128jw_init(spi_host_t spi_host) {
     flash_power_up();
 
     // Set QE bit (only FPGA, simulation do not support status registers at all)
-    #ifdef TARGET_PYNQ_Z2
+    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
     if (set_QE_bit() == FLASH_ERROR) return FLASH_ERROR; // Error occurred while setting QE bit
-    #endif // TARGET_PYNQ_Z2
+    #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
     return FLASH_OK; // Success
 }
@@ -410,9 +410,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard(uint32_t addr, void* data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // TARGET_PYNQ_Z2
+        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -551,9 +551,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_standard_dma(uint32_t addr, void* d
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // TARGET_PYNQ_Z2
+        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -609,7 +609,7 @@ w25q_error_codes_t w25q128jw_read_quad(uint32_t addr, void *data, uint32_t lengt
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1,
         #else
         .len        = DUMMY_CLOCKS_SIM-1,
@@ -699,9 +699,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad(uint32_t addr, void *data, uin
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // TARGET_PYNQ_Z2
+        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -757,7 +757,7 @@ w25q_error_codes_t w25q128jw_read_quad_dma(uint32_t addr, void *data, uint32_t l
 
     // Quad read requires dummy clocks
     const uint32_t dummy_clocks_cmd = spi_create_command((spi_command_t){
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         .len        = DUMMY_CLOCKS_FAST_READ_QUAD_IO-1, // W25Q128JW flash needs 4 dummy cycles
         #else
         .len        = DUMMY_CLOCKS_SIM-1, // SPI flash simulation model needs 8 dummy cycles
@@ -865,9 +865,9 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void *data,
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // TARGET_PYNQ_Z2
+        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -1220,9 +1220,9 @@ w25q_error_codes_t erase_and_write(uint32_t addr, uint8_t *data, uint32_t length
         if (status != FLASH_OK) return FLASH_ERROR;
 
         // Erase the sector (no need to do so in simulation)
-        #ifdef TARGET_PYNQ_Z2
+        #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
         w25q128jw_4k_erase(sector_start_addr);
-        #endif // TARGET_PYNQ_Z2
+        #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 
         // Calculate the length of data to write in this sector
         uint32_t write_length = MIN(FLASH_SECTOR_SIZE - (current_addr - sector_start_addr), remaining_length);
@@ -1344,9 +1344,9 @@ static w25q_error_codes_t page_write(uint32_t addr, uint8_t *data, uint32_t leng
     spi_wait_for_ready(&spi);
 
     // Wait for flash to be ready again (FPGA only)
-    #ifdef TARGET_PYNQ_Z2
+    #if defined (TARGET_PYNQ_Z2) || defined(TARGET_ZCU104)
     flash_wait();
-    #endif // TARGET_PYNQ_Z2
+    #endif // (TARGET_PYNQ_Z2 || TARGET_ZCU104)
 }
 
 static w25q_error_codes_t dma_send_toflash(uint8_t *data, uint32_t length) {


### PR DESCRIPTION
The SPI on EPFL programmer was unusable with ZCU104 due to the fact that some functionalities of the driver were enabled only for the pynq-z2.

`#ifdef` in the driver and SPI examples have been update to enable everything with ZCU104.

A target to clean the flash has been added to solve some issues when the content of the flash results corrupted at programming time.

Tested them on zcu104 and it is all working.

This should solve this issue #521 