### PR TITLE
extend riscv_dbg to support multi Harts

### DIFF
--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv
@@ -11,10 +11,12 @@ module core_v_mini_mcu
     parameter ZFINX = 0,
     parameter EXT_XBAR_NMASTER = 0,
     parameter X_EXT = 0,  // eXtension interface in cv32e40x
+    parameter EXT_HARTS = 0,
     //do not touch these parameters
     parameter EXT_XBAR_NMASTER_RND = EXT_XBAR_NMASTER == 0 ? 1 : EXT_XBAR_NMASTER,
     parameter EXT_DOMAINS_RND = core_v_mini_mcu_pkg::EXTERNAL_DOMAINS == 0 ? 1 : core_v_mini_mcu_pkg::EXTERNAL_DOMAINS,
-    parameter NEXT_INT_RND = core_v_mini_mcu_pkg::NEXT_INT == 0 ? 1 : core_v_mini_mcu_pkg::NEXT_INT
+    parameter NEXT_INT_RND = core_v_mini_mcu_pkg::NEXT_INT == 0 ? 1 : core_v_mini_mcu_pkg::NEXT_INT,
+    parameter EXT_HARTS_RND = EXT_HARTS == 0 ? 1 : EXT_HARTS
 ) (
 
     input logic rst_ni,
@@ -300,6 +302,8 @@ module core_v_mini_mcu
     output reg_req_t ext_peripheral_slave_req_o,
     input  reg_rsp_t ext_peripheral_slave_resp_i,
 
+    output logic [EXT_HARTS_RND-1:0] ext_debug_req_o,
+
     input logic [NEXT_INT_RND-1:0] intr_vector_ext_i,
 
     output logic cpu_subsystem_powergate_switch_no,
@@ -328,6 +332,7 @@ module core_v_mini_mcu
   localparam DM_HALTADDRESS = core_v_mini_mcu_pkg::DEBUG_START_ADDRESS + 32'h00000800; //debug rom code (section .text in linker) starts at 0x800
 
   localparam JTAG_IDCODE = 32'h10001c05;
+  localparam NRHARTS = EXT_HARTS + 1;  //external harts + single hart core-v-mini-mcu
   localparam BOOT_ADDR = core_v_mini_mcu_pkg::BOOTROM_START_ADDRESS;
   localparam NUM_MHPMCOUNTERS = 1;
 
@@ -369,7 +374,7 @@ module core_v_mini_mcu
   // signals to debug unit
   logic debug_core_req;
   logic debug_reset_n;
-
+  logic [NRHARTS-1:0] debug_req;
   // core
   logic core_sleep;
 
@@ -479,6 +484,7 @@ module core_v_mini_mcu
   );
 
   debug_subsystem #(
+      .NRHARTS    (NRHARTS),
       .JTAG_IDCODE(JTAG_IDCODE)
   ) debug_subsystem_i (
       .clk_i,
@@ -488,7 +494,7 @@ module core_v_mini_mcu
       .jtag_trst_ni,
       .jtag_tdi_i,
       .jtag_tdo_o,
-      .debug_core_req_o(debug_core_req),
+      .debug_core_req_o(debug_req),
       .debug_ndmreset_no(debug_reset_n),
       .debug_slave_req_i(debug_slave_req),
       .debug_slave_resp_o(debug_slave_resp),
@@ -692,6 +698,19 @@ module core_v_mini_mcu
       .i2s_sd_i(i2s_sd_i),
       .i2s_rx_valid_o(i2s_rx_valid)
   );
+
+  // Debug_req assign
+  if (NRHARTS == 1) begin
+    assign debug_core_req  = debug_req;
+    assign ext_debug_req_o = 1'b0;
+  end else begin
+    always @(*) begin
+      for (int i = 0; i < NRHARTS; i++) begin
+        if (i == 0) debug_core_req = debug_req[i];
+        else ext_debug_req_o[i-1] = debug_req[i];
+      end
+    end
+  end
 
   assign pdm2pcm_pdm_o    = 0;
   assign pdm2pcm_pdm_oe_o = 0;

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv
@@ -303,6 +303,7 @@ module core_v_mini_mcu
     input  reg_rsp_t ext_peripheral_slave_resp_i,
 
     output logic [EXT_HARTS_RND-1:0] ext_debug_req_o,
+    output logic ext_debug_reset_no,
 
     input logic [NEXT_INT_RND-1:0] intr_vector_ext_i,
 
@@ -316,6 +317,7 @@ module core_v_mini_mcu
     input logic [EXT_DOMAINS_RND-1:0] external_subsystem_powergate_switch_ack_ni,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_powergate_iso_no,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_rst_no,
+    output logic ext_cpu_subsystem_rst_no,
     output logic [EXT_DOMAINS_RND-1:0] external_ram_banks_set_retentive_no,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_clkgate_en_no,
 
@@ -712,104 +714,107 @@ module core_v_mini_mcu
     end
   end
 
-  assign pdm2pcm_pdm_o    = 0;
-  assign pdm2pcm_pdm_oe_o = 0;
+  assign ext_cpu_subsystem_rst_no = cpu_subsystem_rst_n;
+  assign ext_debug_reset_no       = debug_reset_n;
 
-  assign gpio_ao_in[0]    = gpio_0_i;
-  assign gpio_0_o         = gpio_ao_out[0];
-  assign gpio_0_oe_o      = gpio_ao_oe[0];
-  assign gpio_ao_in[1]    = gpio_1_i;
-  assign gpio_1_o         = gpio_ao_out[1];
-  assign gpio_1_oe_o      = gpio_ao_oe[1];
-  assign gpio_ao_in[2]    = gpio_2_i;
-  assign gpio_2_o         = gpio_ao_out[2];
-  assign gpio_2_oe_o      = gpio_ao_oe[2];
-  assign gpio_ao_in[3]    = gpio_3_i;
-  assign gpio_3_o         = gpio_ao_out[3];
-  assign gpio_3_oe_o      = gpio_ao_oe[3];
-  assign gpio_ao_in[4]    = gpio_4_i;
-  assign gpio_4_o         = gpio_ao_out[4];
-  assign gpio_4_oe_o      = gpio_ao_oe[4];
-  assign gpio_ao_in[5]    = gpio_5_i;
-  assign gpio_5_o         = gpio_ao_out[5];
-  assign gpio_5_oe_o      = gpio_ao_oe[5];
-  assign gpio_ao_in[6]    = gpio_6_i;
-  assign gpio_6_o         = gpio_ao_out[6];
-  assign gpio_6_oe_o      = gpio_ao_oe[6];
-  assign gpio_ao_in[7]    = gpio_7_i;
-  assign gpio_7_o         = gpio_ao_out[7];
-  assign gpio_7_oe_o      = gpio_ao_oe[7];
-  assign gpio_in[8]       = gpio_8_i;
-  assign gpio_8_o         = gpio_out[8];
-  assign gpio_8_oe_o      = gpio_oe[8];
-  assign gpio_in[9]       = gpio_9_i;
-  assign gpio_9_o         = gpio_out[9];
-  assign gpio_9_oe_o      = gpio_oe[9];
-  assign gpio_in[10]      = gpio_10_i;
-  assign gpio_10_o        = gpio_out[10];
-  assign gpio_10_oe_o     = gpio_oe[10];
-  assign gpio_in[11]      = gpio_11_i;
-  assign gpio_11_o        = gpio_out[11];
-  assign gpio_11_oe_o     = gpio_oe[11];
-  assign gpio_in[12]      = gpio_12_i;
-  assign gpio_12_o        = gpio_out[12];
-  assign gpio_12_oe_o     = gpio_oe[12];
-  assign gpio_in[13]      = gpio_13_i;
-  assign gpio_13_o        = gpio_out[13];
-  assign gpio_13_oe_o     = gpio_oe[13];
-  assign gpio_in[14]      = gpio_14_i;
-  assign gpio_14_o        = gpio_out[14];
-  assign gpio_14_oe_o     = gpio_oe[14];
-  assign gpio_in[15]      = gpio_15_i;
-  assign gpio_15_o        = gpio_out[15];
-  assign gpio_15_oe_o     = gpio_oe[15];
-  assign gpio_in[16]      = gpio_16_i;
-  assign gpio_16_o        = gpio_out[16];
-  assign gpio_16_oe_o     = gpio_oe[16];
-  assign gpio_in[17]      = gpio_17_i;
-  assign gpio_17_o        = gpio_out[17];
-  assign gpio_17_oe_o     = gpio_oe[17];
-  assign gpio_in[18]      = gpio_18_i;
-  assign gpio_18_o        = gpio_out[18];
-  assign gpio_18_oe_o     = gpio_oe[18];
-  assign gpio_in[19]      = gpio_19_i;
-  assign gpio_19_o        = gpio_out[19];
-  assign gpio_19_oe_o     = gpio_oe[19];
-  assign gpio_in[20]      = gpio_20_i;
-  assign gpio_20_o        = gpio_out[20];
-  assign gpio_20_oe_o     = gpio_oe[20];
-  assign gpio_in[21]      = gpio_21_i;
-  assign gpio_21_o        = gpio_out[21];
-  assign gpio_21_oe_o     = gpio_oe[21];
-  assign gpio_in[22]      = gpio_22_i;
-  assign gpio_22_o        = gpio_out[22];
-  assign gpio_22_oe_o     = gpio_oe[22];
-  assign gpio_in[23]      = gpio_23_i;
-  assign gpio_23_o        = gpio_out[23];
-  assign gpio_23_oe_o     = gpio_oe[23];
-  assign gpio_in[24]      = gpio_24_i;
-  assign gpio_24_o        = gpio_out[24];
-  assign gpio_24_oe_o     = gpio_oe[24];
-  assign gpio_in[25]      = gpio_25_i;
-  assign gpio_25_o        = gpio_out[25];
-  assign gpio_25_oe_o     = gpio_oe[25];
-  assign gpio_in[26]      = gpio_26_i;
-  assign gpio_26_o        = gpio_out[26];
-  assign gpio_26_oe_o     = gpio_oe[26];
-  assign gpio_in[27]      = gpio_27_i;
-  assign gpio_27_o        = gpio_out[27];
-  assign gpio_27_oe_o     = gpio_oe[27];
-  assign gpio_in[28]      = gpio_28_i;
-  assign gpio_28_o        = gpio_out[28];
-  assign gpio_28_oe_o     = gpio_oe[28];
-  assign gpio_in[29]      = gpio_29_i;
-  assign gpio_29_o        = gpio_out[29];
-  assign gpio_29_oe_o     = gpio_oe[29];
-  assign gpio_in[30]      = gpio_30_i;
-  assign gpio_30_o        = gpio_out[30];
-  assign gpio_30_oe_o     = gpio_oe[30];
-  assign gpio_in[31]      = gpio_31_i;
-  assign gpio_31_o        = gpio_out[31];
-  assign gpio_31_oe_o     = gpio_oe[31];
+  assign pdm2pcm_pdm_o            = 0;
+  assign pdm2pcm_pdm_oe_o         = 0;
+
+  assign gpio_ao_in[0]            = gpio_0_i;
+  assign gpio_0_o                 = gpio_ao_out[0];
+  assign gpio_0_oe_o              = gpio_ao_oe[0];
+  assign gpio_ao_in[1]            = gpio_1_i;
+  assign gpio_1_o                 = gpio_ao_out[1];
+  assign gpio_1_oe_o              = gpio_ao_oe[1];
+  assign gpio_ao_in[2]            = gpio_2_i;
+  assign gpio_2_o                 = gpio_ao_out[2];
+  assign gpio_2_oe_o              = gpio_ao_oe[2];
+  assign gpio_ao_in[3]            = gpio_3_i;
+  assign gpio_3_o                 = gpio_ao_out[3];
+  assign gpio_3_oe_o              = gpio_ao_oe[3];
+  assign gpio_ao_in[4]            = gpio_4_i;
+  assign gpio_4_o                 = gpio_ao_out[4];
+  assign gpio_4_oe_o              = gpio_ao_oe[4];
+  assign gpio_ao_in[5]            = gpio_5_i;
+  assign gpio_5_o                 = gpio_ao_out[5];
+  assign gpio_5_oe_o              = gpio_ao_oe[5];
+  assign gpio_ao_in[6]            = gpio_6_i;
+  assign gpio_6_o                 = gpio_ao_out[6];
+  assign gpio_6_oe_o              = gpio_ao_oe[6];
+  assign gpio_ao_in[7]            = gpio_7_i;
+  assign gpio_7_o                 = gpio_ao_out[7];
+  assign gpio_7_oe_o              = gpio_ao_oe[7];
+  assign gpio_in[8]               = gpio_8_i;
+  assign gpio_8_o                 = gpio_out[8];
+  assign gpio_8_oe_o              = gpio_oe[8];
+  assign gpio_in[9]               = gpio_9_i;
+  assign gpio_9_o                 = gpio_out[9];
+  assign gpio_9_oe_o              = gpio_oe[9];
+  assign gpio_in[10]              = gpio_10_i;
+  assign gpio_10_o                = gpio_out[10];
+  assign gpio_10_oe_o             = gpio_oe[10];
+  assign gpio_in[11]              = gpio_11_i;
+  assign gpio_11_o                = gpio_out[11];
+  assign gpio_11_oe_o             = gpio_oe[11];
+  assign gpio_in[12]              = gpio_12_i;
+  assign gpio_12_o                = gpio_out[12];
+  assign gpio_12_oe_o             = gpio_oe[12];
+  assign gpio_in[13]              = gpio_13_i;
+  assign gpio_13_o                = gpio_out[13];
+  assign gpio_13_oe_o             = gpio_oe[13];
+  assign gpio_in[14]              = gpio_14_i;
+  assign gpio_14_o                = gpio_out[14];
+  assign gpio_14_oe_o             = gpio_oe[14];
+  assign gpio_in[15]              = gpio_15_i;
+  assign gpio_15_o                = gpio_out[15];
+  assign gpio_15_oe_o             = gpio_oe[15];
+  assign gpio_in[16]              = gpio_16_i;
+  assign gpio_16_o                = gpio_out[16];
+  assign gpio_16_oe_o             = gpio_oe[16];
+  assign gpio_in[17]              = gpio_17_i;
+  assign gpio_17_o                = gpio_out[17];
+  assign gpio_17_oe_o             = gpio_oe[17];
+  assign gpio_in[18]              = gpio_18_i;
+  assign gpio_18_o                = gpio_out[18];
+  assign gpio_18_oe_o             = gpio_oe[18];
+  assign gpio_in[19]              = gpio_19_i;
+  assign gpio_19_o                = gpio_out[19];
+  assign gpio_19_oe_o             = gpio_oe[19];
+  assign gpio_in[20]              = gpio_20_i;
+  assign gpio_20_o                = gpio_out[20];
+  assign gpio_20_oe_o             = gpio_oe[20];
+  assign gpio_in[21]              = gpio_21_i;
+  assign gpio_21_o                = gpio_out[21];
+  assign gpio_21_oe_o             = gpio_oe[21];
+  assign gpio_in[22]              = gpio_22_i;
+  assign gpio_22_o                = gpio_out[22];
+  assign gpio_22_oe_o             = gpio_oe[22];
+  assign gpio_in[23]              = gpio_23_i;
+  assign gpio_23_o                = gpio_out[23];
+  assign gpio_23_oe_o             = gpio_oe[23];
+  assign gpio_in[24]              = gpio_24_i;
+  assign gpio_24_o                = gpio_out[24];
+  assign gpio_24_oe_o             = gpio_oe[24];
+  assign gpio_in[25]              = gpio_25_i;
+  assign gpio_25_o                = gpio_out[25];
+  assign gpio_25_oe_o             = gpio_oe[25];
+  assign gpio_in[26]              = gpio_26_i;
+  assign gpio_26_o                = gpio_out[26];
+  assign gpio_26_oe_o             = gpio_oe[26];
+  assign gpio_in[27]              = gpio_27_i;
+  assign gpio_27_o                = gpio_out[27];
+  assign gpio_27_oe_o             = gpio_oe[27];
+  assign gpio_in[28]              = gpio_28_i;
+  assign gpio_28_o                = gpio_out[28];
+  assign gpio_28_oe_o             = gpio_oe[28];
+  assign gpio_in[29]              = gpio_29_i;
+  assign gpio_29_o                = gpio_out[29];
+  assign gpio_29_oe_o             = gpio_oe[29];
+  assign gpio_in[30]              = gpio_30_i;
+  assign gpio_30_o                = gpio_out[30];
+  assign gpio_30_oe_o             = gpio_oe[30];
+  assign gpio_in[31]              = gpio_31_i;
+  assign gpio_31_o                = gpio_out[31];
+  assign gpio_31_oe_o             = gpio_oe[31];
 
 endmodule  // core_v_mini_mcu

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
@@ -11,10 +11,12 @@ module core_v_mini_mcu
     parameter ZFINX = 0,
     parameter EXT_XBAR_NMASTER = 0,
     parameter X_EXT = 0,  // eXtension interface in cv32e40x
+    parameter EXT_HARTS = 0,
     //do not touch these parameters
     parameter EXT_XBAR_NMASTER_RND = EXT_XBAR_NMASTER == 0 ? 1 : EXT_XBAR_NMASTER,
     parameter EXT_DOMAINS_RND = core_v_mini_mcu_pkg::EXTERNAL_DOMAINS == 0 ? 1 : core_v_mini_mcu_pkg::EXTERNAL_DOMAINS,
-    parameter NEXT_INT_RND = core_v_mini_mcu_pkg::NEXT_INT == 0 ? 1 : core_v_mini_mcu_pkg::NEXT_INT
+    parameter NEXT_INT_RND = core_v_mini_mcu_pkg::NEXT_INT == 0 ? 1 : core_v_mini_mcu_pkg::NEXT_INT,
+    parameter EXT_HARTS_RND = EXT_HARTS == 0 ? 1 : EXT_HARTS
 ) (
 
     input logic rst_ni,
@@ -54,6 +56,8 @@ ${pad.core_v_mini_mcu_interface}
     output reg_req_t ext_peripheral_slave_req_o,
     input  reg_rsp_t ext_peripheral_slave_resp_i,
 
+    output logic      [EXT_HARTS_RND-1:0] ext_debug_req_o,
+
     input logic [NEXT_INT_RND-1:0] intr_vector_ext_i,
 
     output logic cpu_subsystem_powergate_switch_no,
@@ -82,6 +86,7 @@ ${pad.core_v_mini_mcu_interface}
   localparam DM_HALTADDRESS = core_v_mini_mcu_pkg::DEBUG_START_ADDRESS + 32'h00000800; //debug rom code (section .text in linker) starts at 0x800
 
   localparam JTAG_IDCODE = 32'h10001c05;
+  localparam NRHARTS = EXT_HARTS + 1; //external harts + single hart core-v-mini-mcu
   localparam BOOT_ADDR = core_v_mini_mcu_pkg::BOOTROM_START_ADDRESS;
   localparam NUM_MHPMCOUNTERS = 1;
 
@@ -123,7 +128,7 @@ ${pad.core_v_mini_mcu_interface}
   // signals to debug unit
   logic debug_core_req;
   logic debug_reset_n;
-
+  logic [NRHARTS-1:0] debug_req;
   // core
   logic core_sleep;
 
@@ -233,6 +238,7 @@ ${pad.core_v_mini_mcu_interface}
   );
 
   debug_subsystem #(
+      .NRHARTS    (NRHARTS),
       .JTAG_IDCODE(JTAG_IDCODE)
   ) debug_subsystem_i (
       .clk_i,
@@ -242,7 +248,7 @@ ${pad.core_v_mini_mcu_interface}
       .jtag_trst_ni,
       .jtag_tdi_i,
       .jtag_tdo_o,
-      .debug_core_req_o(debug_core_req),
+      .debug_core_req_o(debug_req),
       .debug_ndmreset_no(debug_reset_n),
       .debug_slave_req_i(debug_slave_req),
       .debug_slave_resp_o(debug_slave_resp),
@@ -444,6 +450,19 @@ ${pad.core_v_mini_mcu_interface}
       .i2s_sd_i(i2s_sd_i),
       .i2s_rx_valid_o(i2s_rx_valid)
   );
+
+  // Debug_req assign
+  if (NRHARTS == 1) begin
+    assign debug_core_req = debug_req;
+    assign ext_debug_req_o  = 1'b0;
+  end else begin
+    always @(*) begin
+      for (int i = 0; i < NRHARTS; i++) begin
+        if (i == 0) debug_core_req = debug_req[i];
+        else ext_debug_req_o[i-1] = debug_req[i];
+      end
+    end
+  end
 
   assign pdm2pcm_pdm_o = 0;
   assign pdm2pcm_pdm_oe_o = 0;

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
@@ -56,7 +56,8 @@ ${pad.core_v_mini_mcu_interface}
     output reg_req_t ext_peripheral_slave_req_o,
     input  reg_rsp_t ext_peripheral_slave_resp_i,
 
-    output logic      [EXT_HARTS_RND-1:0] ext_debug_req_o,
+    output logic  [EXT_HARTS_RND-1:0] ext_debug_req_o,
+    output logic  ext_debug_reset_no,
 
     input logic [NEXT_INT_RND-1:0] intr_vector_ext_i,
 
@@ -70,6 +71,7 @@ ${pad.core_v_mini_mcu_interface}
     input  logic [EXT_DOMAINS_RND-1:0] external_subsystem_powergate_switch_ack_ni,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_powergate_iso_no,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_rst_no,
+    output logic ext_cpu_subsystem_rst_no,
     output logic [EXT_DOMAINS_RND-1:0] external_ram_banks_set_retentive_no,
     output logic [EXT_DOMAINS_RND-1:0] external_subsystem_clkgate_en_no,
 
@@ -463,6 +465,9 @@ ${pad.core_v_mini_mcu_interface}
       end
     end
   end
+
+  assign ext_cpu_subsystem_rst_no = cpu_subsystem_rst_n;
+  assign ext_debug_reset_no = debug_reset_n;
 
   assign pdm2pcm_pdm_o = 0;
   assign pdm2pcm_pdm_oe_o = 0;

--- a/hw/system/x_heep_system.sv.tpl
+++ b/hw/system/x_heep_system.sv.tpl
@@ -74,6 +74,8 @@ ${pad.x_heep_system_interface}
 
 
   logic [EXT_HARTS_RND-1:0] ext_debug_req;
+  logic ext_cpu_subsystem_rst_n;
+  logic ext_debug_reset_n;
 
   // PM signals
   logic cpu_subsystem_powergate_switch_n;
@@ -139,6 +141,7 @@ ${pad.core_v_mini_mcu_bonding}
     .ext_peripheral_slave_req_o,
     .ext_peripheral_slave_resp_i,
     .ext_debug_req_o(ext_debug_req),
+    .ext_debug_reset_no(ext_debug_reset_n),
     .cpu_subsystem_powergate_switch_no(cpu_subsystem_powergate_switch_n),
     .cpu_subsystem_powergate_switch_ack_ni(cpu_subsystem_powergate_switch_ack_n),
     .peripheral_subsystem_powergate_switch_no(peripheral_subsystem_powergate_switch_n),
@@ -149,6 +152,7 @@ ${pad.core_v_mini_mcu_bonding}
     .external_subsystem_powergate_switch_ack_ni,
     .external_subsystem_powergate_iso_no,
     .external_subsystem_rst_no,
+    .ext_cpu_subsystem_rst_no(ext_cpu_subsystem_rst_n),
     .external_ram_banks_set_retentive_no,
     .external_subsystem_clkgate_en_no,
     .exit_value_o,

--- a/hw/system/x_heep_system.sv.tpl
+++ b/hw/system/x_heep_system.sv.tpl
@@ -66,6 +66,15 @@ ${pad.x_heep_system_interface}
 
   import core_v_mini_mcu_pkg::*;
 
+
+  localparam EXT_HARTS = 0;
+
+  //do not touch these parameter
+  localparam EXT_HARTS_RND = EXT_HARTS == 0 ? 1 : EXT_HARTS;
+
+
+  logic [EXT_HARTS_RND-1:0] ext_debug_req;
+
   // PM signals
   logic cpu_subsystem_powergate_switch_n;
   logic cpu_subsystem_powergate_switch_ack_n;
@@ -96,7 +105,8 @@ ${pad.internal_signals}
     .FPU(FPU),
     .ZFINX(ZFINX),
     .EXT_XBAR_NMASTER(EXT_XBAR_NMASTER),
-    .X_EXT(X_EXT)
+    .X_EXT(X_EXT),
+    .EXT_HARTS(EXT_HARTS)
   ) core_v_mini_mcu_i (
 
     .rst_ni(rst_ngen),
@@ -128,6 +138,7 @@ ${pad.core_v_mini_mcu_bonding}
     .ext_dma_addr_ch0_resp_i,
     .ext_peripheral_slave_req_o,
     .ext_peripheral_slave_resp_i,
+    .ext_debug_req_o(ext_debug_req),
     .cpu_subsystem_powergate_switch_no(cpu_subsystem_powergate_switch_n),
     .cpu_subsystem_powergate_switch_ack_ni(cpu_subsystem_powergate_switch_ack_n),
     .peripheral_subsystem_powergate_switch_no(peripheral_subsystem_powergate_switch_n),

--- a/hw/vendor/patches/pulp_platform_riscv_dbg/fix_nrharts.patch
+++ b/hw/vendor/patches/pulp_platform_riscv_dbg/fix_nrharts.patch
@@ -1,0 +1,28 @@
+diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
+index 59d1c90..2338028 100644
+--- a/src/dm_csrs.sv
++++ b/src/dm_csrs.sv
+@@ -547,7 +547,7 @@ module dm_csrs #(
+     if (!dmcontrol_q.resumereq && dmcontrol_d.resumereq) begin
+       clear_resumeack_o = 1'b1;
+     end
+-    if (dmcontrol_q.resumereq && resumeack_i) begin
++    if (dmcontrol_q.resumereq && resumeack_i[selected_hart]) begin
+       dmcontrol_d.resumereq = 1'b0;
+     end
+     // static values for dcsr
+diff --git a/src/dm_mem.sv b/src/dm_mem.sv
+index 9ff3c86..8f97bec 100755
+--- a/src/dm_mem.sv
++++ b/src/dm_mem.sv
+@@ -535,8 +535,8 @@ module dm_mem #(
+ 
+   always_ff @(posedge clk_i or negedge rst_ni) begin
+     if (!rst_ni) begin
+-      halted_q   <= 1'b0;
+-      resuming_q <= 1'b0;
++        halted_q   <= '0;
++        resuming_q <= '0;
+     end else begin
+       halted_q   <= SelectableHarts & halted_d;
+       resuming_q <= SelectableHarts & resuming_d;

--- a/hw/vendor/pulp_platform_riscv_dbg.vendor.hjson
+++ b/hw/vendor/pulp_platform_riscv_dbg.vendor.hjson
@@ -10,6 +10,8 @@
     rev: "358f90110220adf7a083f8b65d157e836d706236",
   },
 
+  patch_dir: "patches/pulp_platform_riscv_dbg",
+
   exclude_from_upstream: [
     "ci",
     "tb",

--- a/hw/vendor/pulp_platform_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_platform_riscv_dbg/src/dm_csrs.sv
@@ -547,7 +547,7 @@ module dm_csrs #(
     if (!dmcontrol_q.resumereq && dmcontrol_d.resumereq) begin
       clear_resumeack_o = 1'b1;
     end
-    if (dmcontrol_q.resumereq && resumeack_i[selected_hart]) begin 
+    if (dmcontrol_q.resumereq && resumeack_i[selected_hart]) begin
       dmcontrol_d.resumereq = 1'b0;
     end
     // static values for dcsr

--- a/hw/vendor/pulp_platform_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_platform_riscv_dbg/src/dm_csrs.sv
@@ -547,7 +547,7 @@ module dm_csrs #(
     if (!dmcontrol_q.resumereq && dmcontrol_d.resumereq) begin
       clear_resumeack_o = 1'b1;
     end
-    if (dmcontrol_q.resumereq && resumeack_i) begin
+    if (dmcontrol_q.resumereq && resumeack_i[selected_hart]) begin 
       dmcontrol_d.resumereq = 1'b0;
     end
     // static values for dcsr

--- a/hw/vendor/pulp_platform_riscv_dbg/src/dm_mem.sv
+++ b/hw/vendor/pulp_platform_riscv_dbg/src/dm_mem.sv
@@ -535,8 +535,8 @@ module dm_mem #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      halted_q   <= 1'b0;
-      resuming_q <= 1'b0;
+        halted_q   <= '0;
+        resuming_q <= '0;
     end else begin
       halted_q   <= SelectableHarts & halted_d;
       resuming_q <= SelectableHarts & resuming_d;

--- a/hw/vendor/waiver/lint/riscv_dbg.vlt
+++ b/hw/vendor/waiver/lint/riscv_dbg.vlt
@@ -12,3 +12,4 @@ lint_off -rule DECLFILENAME -file "*/src/cdc_fifo_gray_clearable.sv" -match "Fil
 lint_off -rule WIDTH -file "*/src/cdc_2phase_clearable.sv" -match "Logical operator GENIF expects 1 bit on the If, but If's VARREF 'CLEAR_ON_ASYNC_RESET' generates 32 bits.*"
 lint_off -rule UNOPTFLAT -file "*/src/cdc_4phase.sv" -match "Signal unoptimizable*"
 lint_off -rule WIDTH -file "*/src/dm_mem.sv" -match "*"
+lint_off -rule CMPCONST -file "*/src/dm_csrs.sv" -match "*"


### PR DESCRIPTION
Fixed some bugs in pulp_platform_riscv_dbg to allow configuration of multiple harts.

Added lint_off rule to avoid warning.