### PR TITLE
fix-malloc

### DIFF
--- a/sw/device/lib/runtime/syscalls.c
+++ b/sw/device/lib/runtime/syscalls.c
@@ -46,6 +46,7 @@ int     _link (const char *__path1, const char *__path2);
 _off_t  _lseek (int __fildes, _off_t __offset, int __whence);
 ssize_t _read (int __fd, void *__buf, size_t __nbyte);
 void *  _sbrk (ptrdiff_t __incr);
+int     _brk(void *addr);
 int     _unlink (const char *__path);
 ssize_t _write (int __fd, const void *__buf, size_t __nbyte);
 int     _execve (const char *__path, char * const __argv[], char * const __envp[]);
@@ -270,8 +271,12 @@ static char *brk = __heap_start;
 
 int _brk(void *addr)
 {
-    brk = addr;
-    return 0;
+    if (addr >= (void *)__heap_start && addr <= (void *)__heap_end) {
+        brk = addr;
+        return 0; 
+    } else {
+        return -1; 
+    }
 }
 
 void *_sbrk(ptrdiff_t incr)
@@ -279,13 +284,13 @@ void *_sbrk(ptrdiff_t incr)
     char *old_brk = brk;
 
     if (__heap_start == __heap_end) {
-        return NULL;
+        return NULL; 
     }
 
-    if ((brk += incr) < __heap_end) {
+    if (brk + incr < __heap_end && brk + incr >= __heap_start) {
         brk += incr;
     } else {
-        brk = __heap_end;
+        return (void *)-1; 
     }
     return old_brk;
 }


### PR DESCRIPTION
Fixed brk() and sbrk() syscalls in sw\device\lib\runtime\syscalls.c