### PR TITLE
Fix #548: use `==` instead of `in` for string comparison in Python/.tpl

### DIFF
--- a/hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl
+++ b/hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl
@@ -292,9 +292,7 @@ module peripheral_subsystem
       .reg_rsp_o(peripheral_slv_rsp[core_v_mini_mcu_pkg::RV_PLIC_IDX])
   );
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("rv_plic"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'rv_plic' in peripherals and peripherals['rv_plic']['is_included'] == 'yes':
   rv_plic rv_plic_i (
       .clk_i(clk_cg),
       .rst_ni,
@@ -315,12 +313,8 @@ module peripheral_subsystem
   assign irq_plic_o = '0;
   assign plic_tl_d2h = '0;
 % endif
-% endif
-% endfor
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("spi_host"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'spi_host' in peripherals and peripherals['spi_host']['is_included'] == 'yes':
   spi_host #(
       .reg_req_t(reg_pkg::reg_req_t),
       .reg_rsp_t(reg_pkg::reg_rsp_t)
@@ -357,14 +351,10 @@ module peripheral_subsystem
   assign spi_rx_valid_o = '0;
   assign spi_tx_ready_o = '0;
 % endif
-% endif
-% endfor
 
 
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("gpio"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'gpio' in peripherals and peripherals['gpio']['is_included'] == 'yes':
   gpio #(
       .reg_req_t(reg_pkg::reg_req_t),
       .reg_rsp_t(reg_pkg::reg_rsp_t)
@@ -386,8 +376,6 @@ module peripheral_subsystem
   assign gpio_intr = '0;
   assign peripheral_slv_rsp[core_v_mini_mcu_pkg::GPIO_IDX] = '0;
 % endif
-% endif
-% endfor
 
   reg_to_tlul #(
       .req_t(reg_pkg::reg_req_t),
@@ -406,9 +394,7 @@ module peripheral_subsystem
       .reg_rsp_o(peripheral_slv_rsp[core_v_mini_mcu_pkg::I2C_IDX])
   );
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("i2c"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'i2c' in peripherals and peripherals['i2c']['is_included'] == 'yes':
   i2c i2c_i (
       .clk_i(clk_cg),
       .rst_ni,
@@ -460,8 +446,6 @@ module peripheral_subsystem
   assign i2c_intr_ack_stop = '0;
   assign i2c_intr_host_timeout = '0;
 % endif
-% endif
-% endfor
 
   reg_to_tlul #(
       .req_t(reg_pkg::reg_req_t),
@@ -480,9 +464,7 @@ module peripheral_subsystem
       .reg_rsp_o(peripheral_slv_rsp[core_v_mini_mcu_pkg::RV_TIMER_IDX])
   );
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("rv_timer"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'rv_timer' in peripherals and peripherals['rv_timer']['is_included'] == 'yes':
   rv_timer rv_timer_2_3_i (
       .clk_i(clk_cg),
       .rst_ni,
@@ -496,12 +478,8 @@ module peripheral_subsystem
   assign rv_timer_2_intr_o = '0;
   assign rv_timer_3_intr_o = '0;
 % endif
-% endif
-% endfor
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("spi2"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'spi2' in peripherals and peripherals['spi2']['is_included'] == 'yes':
   spi_host #(
       .reg_req_t(reg_pkg::reg_req_t),
       .reg_rsp_t(reg_pkg::reg_rsp_t)
@@ -536,12 +514,8 @@ module peripheral_subsystem
   assign spi2_sd_en_o = '0;
   assign spi2_intr_event = '0;
 % endif
-% endif
-% endfor
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("pdm2pcm"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'pdm2pcm' in peripherals and peripherals['pdm2pcm']['is_included'] == 'yes':
   pdm2pcm #(
       .reg_req_t(reg_pkg::reg_req_t),
       .reg_rsp_t(reg_pkg::reg_rsp_t)
@@ -557,14 +531,10 @@ module peripheral_subsystem
   assign peripheral_slv_rsp[core_v_mini_mcu_pkg::PDM2PCM_IDX] = '0;
   assign pdm2pcm_clk_o = '0;
 % endif
-% endif
-% endfor
 
   assign pdm2pcm_clk_en_o = 1;
 
-% for peripheral in peripherals.items():
-% if peripheral[0] in ("i2s"):
-% if peripheral[1]['is_included'] in ("yes"):
+% if 'i2s' in peripherals and peripherals['i2s']['is_included'] == 'yes':
   i2s #(
       .reg_req_t(reg_pkg::reg_req_t),
       .reg_rsp_t(reg_pkg::reg_rsp_t)
@@ -598,7 +568,5 @@ module peripheral_subsystem
   assign i2s_intr_event   = 1'b0;
   assign i2s_rx_valid_o   = 1'b0;
 % endif
-% endif
-% endfor
 
 endmodule : peripheral_subsystem

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -220,7 +220,7 @@ class Pad:
     self.pad_mapping = pad_mapping
     self.pad_mux_list = pad_mux_list
 
-    if('low' in pad_active):
+    if pad_active == 'low':
         name_active = 'n'
     else:
         name_active = ''
@@ -626,7 +626,7 @@ def main():
             if isinstance(info, dict):
                 new_info = {}
                 for k, v in info.items():
-                    if k not in ("is_included"):
+                    if k != "is_included":
                         new_info[k] = string2int(v)
                     else:
                         new_info[k] = v
@@ -639,7 +639,7 @@ def main():
         new = {}
         for k,v in peripherals.items():
             if isinstance(v, dict):
-                new[k] = {key:val for key,val in v.items() if key not in ("path")}
+                new[k] = {key:val for key,val in v.items() if key != "path"}
             else:
                 new[k] = v
         return new
@@ -648,10 +648,8 @@ def main():
         len_ep = 0
         for name, info in peripherals.items():
             if isinstance(info, dict):
-                for k, v in info.items():
-                   if k in ("is_included"):
-                    if v in ("yes"):
-                        len_ep += 1
+                if info['is_included'] == "yes":
+                    len_ep += 1
         return len_ep
 
     ao_peripherals = extract_peripherals(discard_path(obj['ao_peripherals']))
@@ -794,7 +792,7 @@ def main():
             pad_mux_list_hjson = []
 
         try:
-            if ('True' in pads[key]['driven_manually']):
+            if pads[key]['driven_manually'] == 'True':
                 pad_driven_manually = True
             else:
                 pad_driven_manually = False
@@ -802,7 +800,7 @@ def main():
             pad_driven_manually = False
 
         try:
-            if ('True' in pads[key]['skip_declaration']):
+            if pads[key]['skip_declaration'] == 'True':
                 pad_skip_declaration = True
             else:
                 pad_skip_declaration = False
@@ -810,7 +808,7 @@ def main():
             pad_skip_declaration = False
 
         try:
-            if ('True' in pads[key]['keep_internal']):
+            if pads[key]['keep_internal'] == 'True':
                 pad_keep_internal = True
             else:
                 pad_keep_internal = False
@@ -857,7 +855,7 @@ def main():
                 pad_active_mux = 'high'
 
             try:
-                if ('True' in pads[key]['mux'][pad_mux]['driven_manually']):
+                if pads[key]['mux'][pad_mux]['driven_manually'] == 'True':
                     pad_driven_manually_mux = True
                 else:
                     pad_driven_manually_mux = False
@@ -865,7 +863,7 @@ def main():
                 pad_driven_manually_mux = False
 
             try:
-                if ('True' in pads[key]['mux'][pad_mux]['skip_declaration']):
+                if pads[key]['mux'][pad_mux]['skip_declaration'] == 'True':
                     pad_skip_declaration_mux = True
                 else:
                     pad_skip_declaration_mux = False
@@ -943,7 +941,7 @@ def main():
                 pad_mux_list_hjson = []
 
             try:
-                if ('True' in external_pads[key]['driven_manually']):
+                if external_pads[key]['driven_manually'] == 'True':
                     pad_driven_manually = True
                 else:
                     pad_driven_manually = False
@@ -951,7 +949,7 @@ def main():
                 pad_driven_manually = False
 
             try:
-                if ('True' in external_pads[key]['skip_declaration']):
+                if external_pads[key]['skip_declaration'] == 'True':
                     pad_skip_declaration = True
                 else:
                     pad_skip_declaration = False
@@ -998,7 +996,7 @@ def main():
                     pad_active_mux = 'high'
 
                 try:
-                    if ('True' in external_pads[key]['mux'][pad_mux]['driven_manually']):
+                    if external_pads[key]['mux'][pad_mux]['driven_manually'] == 'True':
                         pad_driven_manually_mux = True
                     else:
                         pad_driven_manually_mux = False
@@ -1006,7 +1004,7 @@ def main():
                     pad_driven_manually_mux = False
 
                 try:
-                    if ('True' in external_pads[key]['mux'][pad_mux]['skip_declaration']):
+                    if external_pads[key]['mux'][pad_mux]['skip_declaration'] == 'True':
                         pad_skip_declaration_mux = True
                     else:
                         pad_skip_declaration_mux = False


### PR DESCRIPTION
The use of `in` for string comparison results in `"name" in "name2"` giving a false positive; the right thing is to use `==`.
In peripheral_subsystem.sv.tpl, this may result in the peripheral being added twice, or being added when it shouldn't.  This was reported in #548, and has been fixed in this PR.
This misuse of `in` also occurs in mcu_gen.py and has been fixed as well.

In addition, this PR also changes the way in which dict keys are handled, from iterating through all the keys to just finding the relevant key, which is more readable (and efficient).