### PR TITLE
remove pow function to avoid errors in Synopsys DC

### DIFF
--- a/hw/ip/pdm2pcm/rtl/fir.sv
+++ b/hw/ip/pdm2pcm/rtl/fir.sv
@@ -48,7 +48,9 @@ module fir #(
   genvar k;
   generate
     for (k = 0; k < TOTCOEFS; k = k + 1) begin : coeffs_mapping
-      assign coeffs[k] = freecoeffs[int'($floor($sqrt($pow((TOTCOEFS-1)/2.0-k, 2))))];
+      // Remove $pow function to avoid errors in Synopsys DC
+      // assign coeffs[k] = freecoeffs[int'($floor($sqrt($pow((TOTCOEFS-1)/2.0-k, 2))))];
+      assign coeffs[k] = freecoeffs[int'($floor($sqrt(((TOTCOEFS-1)/2.0-k)*((TOTCOEFS-1)/2.0-k))))];
     end
   endgenerate
 

--- a/hw/ip/pdm2pcm/rtl/halfband.sv
+++ b/hw/ip/pdm2pcm/rtl/halfband.sv
@@ -63,7 +63,11 @@ module halfband #(
   genvar k;
   generate
     for (k = 0; k < TOTCOEFS; k = k + 1) begin : coeffs_mapping
-      assign coeffs[k] = lessfreecoeffs[int'($floor($sqrt($pow((TOTCOEFS-1)/2.0-k, 2))))];
+      // Remove $pow function to avoid errors in Synopsys DC
+      // assign coeffs[k] = lessfreecoeffs[int'($floor($sqrt($pow((TOTCOEFS-1)/2.0-k, 2))))];
+      assign coeffs[k] = lessfreecoeffs[int'($floor(
+          $sqrt(((TOTCOEFS-1)/2.0-k)*((TOTCOEFS-1)/2.0-k))
+      ))];
     end
   endgenerate
 


### PR DESCRIPTION
Closes #558 

Change the way to compute a power of two in SystemVerilog to avoid elaboration errors in Synopsys Design Compiler.