### PR TITLE
Fix-timer-sdk

### DIFF
--- a/docs/source/Peripherals/Timer.md
+++ b/docs/source/Peripherals/Timer.md
@@ -99,7 +99,7 @@ void timer_wait_us(uint32_t ms);
 Get the time taken to execute a certain number of cycles, returned as a float representing the time in microseconds.
 
 ```c
-float get_time(uint32_t cycles);
+float get_time_from_cycles(uint32_t cycles);
 ```
 
 ## Example Usage

--- a/docs/source/Peripherals/Timer.md
+++ b/docs/source/Peripherals/Timer.md
@@ -1,0 +1,107 @@
+
+# Timer SDK
+
+This SDK provides utilities for execution time measurements using HW timers. It includes functions to start, stop, reset, and configure timers, as well as to enable timer interrupts and measure elapsed time.
+
+## Usage
+
+The SDK provides a set of functions to interact with the HW Timer for various timing operations.
+
+### Initialize Timer for Counting Cycles
+
+This function configures the counter at the running clock frequency to count the number of clock cycles. Call this function before any of the other timer SDK functions.
+
+```c
+void timer_cycles_init();
+```
+
+### Start Timer
+
+Start the HW timer.
+
+```c
+void timer_start();
+```
+
+### Get Current Timer Value
+
+Retrieve the current value of the HW timer without stopping it.
+
+```c
+uint32_t timer_get_cycles();
+```
+
+### Complete timer reset
+
+Completely resets the HW counter, disabling all IRQs, counters, and comparators.
+```c
+void timer_reset();
+```
+ 
+### Stop and Reset Timer
+
+Retrieve the current value of the HW timer and stop it.
+
+```c
+uint32_t timer_stop();
+```
+
+### Set Timer Threshold
+
+Set the timer to go off once the counter value reaches the specified threshold. If the timer interrupts and the timer IRQ have been enabled, when the timer reaches that value an interrupt will be called.
+
+```c
+void timer_arm_set(uint32_t threshold);
+```
+
+### Set Timer Threshold and Start
+
+Set the timer to go off once the counter value reaches the specified threshold, and start the timer. If the timer interrupts and the timer IRQ have been enabled, when the timer reaches that value an interrupt will be called.
+
+```c
+void timer_arm_start(uint32_t threshold);
+```
+
+### Enable Timer IRQ
+
+Enable the timer interrupt request.
+
+```c
+void timer_irq_enable();
+```
+
+### Clear Timer IRQ
+
+Clear the timer interrupt request.
+
+```c
+void timer_irq_clear();
+```
+
+### Enable Timer Machine-level Interrupts
+
+Enable the timer machine-level interrupts for the X-Heep platform.
+
+```c
+void enable_timer_interrupt();
+```
+
+### Wait for Microseconds
+
+Block execution for a specified number of microseconds. This function is not precise for small numbers of microseconds. Enable timer interrupts with `enable_timer_interrupt()` before using this function.
+
+```c
+void timer_wait_us(uint32_t ms);
+```
+
+### Get Execution Time in Microseconds
+
+Get the time taken to execute a certain number of cycles, returned as a float representing the time in microseconds.
+
+```c
+float get_time(uint32_t cycles);
+```
+
+## Example Usage
+
+An example of utilization of the timer SDK can be found in `sw/applications/example_timer_sdk/main.c`.

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -5,6 +5,8 @@
 // File: example_timer_sdk.c
 // Author: Juan Sapriza, Francesco Poluzzi
 // Date: 23/07/2024
+// Author: Juan Sapriza, Francesco Poluzzi
+// Date: 23/07/2024
 // Description: Example application to test the Timer SDK. Will count the time to execute a few short tasks.
 
 #include <stdint.h>
@@ -15,7 +17,12 @@
 
 /* By default, printfs are activated for FPGA and disabled for simulation. */
 #define PRINTF_IN_FPGA  1
-#define PRINTF_IN_SIM   1
+#define PRINTF_IN_SIM   0
+
+/* Error tolerances for the tests. */
+#define CYCLE_TOLERANCE  2         // cycles tolerance for simple timer reads
+#define INTERRUPT_TOLERANCE 50     // cycles tolerance for timer interrupt
+#define TIMER_WAIT_TOLERANCE 100   // milliseconds tolerance for timer wait
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
@@ -34,50 +41,70 @@ void __attribute__((aligned(4), interrupt)) handler_irq_timer(void) {
 int main(){
     uint32_t i = 0;
     uint32_t timer_cycles;
+    uint32_t nop_cycles[4];
 
-    timer_init();               // Init the timer SDK for clock cycles
+    timer_cycles_init();               // Init the timer SDK for clock cycles
     timer_start();              // Start counting the time
-    timer_cycles = timer_stop();  // Stop counting the time
-    PRINTF("0 NOPs:\t%d cc\n\r", timer_cycles );
-    
+    nop_cycles[0] = timer_stop();  // Stop counting the time
+    PRINTF("0 NOPs:\t%d cc\n\r", nop_cycles[0] );
+      
     timer_start();     
     asm volatile ("nop");
-    timer_cycles = timer_stop();  
-    PRINTF("1 NOP:\t%d cc\n\r", timer_cycles );
+    nop_cycles[1] = timer_stop();  
+    PRINTF("1 NOP:\t%d cc\n\r", nop_cycles[1] );
     
     timer_start();              
     asm volatile ("nop");
     asm volatile ("nop");
-    timer_cycles = timer_stop();  
-    PRINTF("2 NOPs:\t%d cc\n\r", timer_cycles );
+    nop_cycles[2] = timer_stop();  
+    PRINTF("2 NOPs:\t%d cc\n\r", nop_cycles[2] );
 
     timer_start();              
     asm volatile ("nop");
     asm volatile ("nop");
     asm volatile ("nop");
-    timer_cycles = timer_stop();  
-    PRINTF("3 NOPs:\t%d cc\n\r", timer_cycles );
+    nop_cycles[3] = timer_stop();  
+    PRINTF("3 NOPs:\t%d cc\n\r", nop_cycles[3] );
+
+    if( abs(nop_cycles[1] - nop_cycles[0])>CYCLE_TOLERANCE || abs(nop_cycles[2] - nop_cycles[1])>CYCLE_TOLERANCE || abs(nop_cycles[3] - nop_cycles[2])>CYCLE_TOLERANCE){ 
+        PRINTF("Clock count failed\n\r");
+        return EXIT_FAILURE;
+    } 
 
     enable_timer_interrupt();   // Enable the timer machine-level interrupt
 
-    timer_init();
+    timer_cycles_init();
     timer_irq_enable();
     timer_arm_start(1000);
     timer_start();              
     asm volatile ("wfi");       // Wait for interrupt
     timer_cycles = timer_stop();  
-    PRINTF("wait ARM timer 1000 (%d)\n\r", timer_cycles );
-
-    timer_init_us();           // Init the timer SDK for microseconds
+    if(abs(timer_cycles-1000) < INTERRUPT_TOLERANCE){ 
+        PRINTF("Timer thershold interrupt working\n" );
+    } else {
+        PRINTF("Timer thershold interrupt failed\n\r");
+        return EXIT_FAILURE;
+    }
+    
+    timer_microseconds_init();           // Init the timer SDK for microseconds
     timer_start(); 
     for(i = 0; i < 1000; i++){
         asm volatile ("nop");
     }
-    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", timer_stop() );
+    timer_cycles = timer_stop();  
+    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", timer_cycles );
 
     PRINTF("Wait 5 seconds\n\r");
     timer_wait_ms(5000);       // Wait for 5 seconds
     PRINTF("Done\n\r");
+    timer_cycles = timer_stop(); 
 
+    if(abs(timer_cycles/1000)-5000 > TIMER_WAIT_TOLERANCE){ 
+        PRINTF("Timer wait failed\n\r");
+        return EXIT_FAILURE;
+    }
+
+    PRINTF("All tests passed\n\r");
     return EXIT_SUCCESS;
 }
+

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -96,7 +96,7 @@ int main(){
         asm volatile ("nop");
     }
     timer_cycles = timer_stop();  
-    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", (uint32_t)get_time(timer_cycles) );
+    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", (uint32_t)get_time_from_cycles(timer_cycles) );
 
     PRINTF("Wait 5 seconds\n\r");
     timer_wait_us(5000000);       // Wait for 5 seconds 

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -98,17 +98,29 @@ int main(){
     timer_cycles = timer_stop();  
     PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", (uint32_t)get_time_from_cycles(timer_cycles) );
 
-    PRINTF("Wait 5 seconds\n\r");
-    timer_wait_us(5000000);       // Wait for 5 seconds 
-    timer_cycles = timer_stop();     
-    PRINTF("Done\n\r");
+    #ifdef TARGET_IS_FPGA
+        PRINTF("Wait 5 second\n\r");
+        timer_wait_us(5000000);       // Wait for 5 seconds 
+        timer_cycles = timer_stop();     
+        PRINTF("Done\n\r");
 
-    if(abs(timer_cycles-(5*freq_hz)) > TIMER_WAIT_TOLERANCE){ 
-        PRINTF("Timer wait failed\n\r");
-        return EXIT_FAILURE;
-    }
+        if(abs(timer_cycles-(5*freq_hz)) > TIMER_WAIT_TOLERANCE){ 
+            PRINTF("Timer wait failed\n\r");
+            return EXIT_FAILURE;
+        }
+    #endif
+    #ifdef TARGET_SIM  // Reduced time for simulation for faster testing
+        PRINTF("Wait 0.001 second\n\r");
+        timer_wait_us(1000);       // Wait for 1 millisecond
+        timer_cycles = timer_stop();     
+        PRINTF("Done\n\r");
+
+        if(abs(timer_cycles-(0.001*freq_hz)) > TIMER_WAIT_TOLERANCE){ 
+            PRINTF("Timer wait failed\n\r");
+            return EXIT_FAILURE;
+        }
+    #endif
 
     PRINTF("All tests passed\n\r");
     return EXIT_SUCCESS;
 }
-

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -21,7 +21,7 @@
 
 /* Error tolerances for the tests. */
 #define CYCLE_TOLERANCE  2         // cycles tolerance for simple timer reads
-#define INTERRUPT_TOLERANCE 60     // cycles tolerance for timer interrupt
+#define INTERRUPT_TOLERANCE 70     // cycles tolerance for timer interrupt
 #define TIMER_WAIT_TOLERANCE 20   // milliseconds tolerance for timer wait
 
 #if TARGET_SIM && PRINTF_IN_SIM

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -5,12 +5,11 @@
 // File: example_timer_sdk.c
 // Author: Juan Sapriza, Francesco Poluzzi
 // Date: 23/07/2024
-// Author: Juan Sapriza, Francesco Poluzzi
-// Date: 23/07/2024
 // Description: Example application to test the Timer SDK. Will count the time to execute a few short tasks.
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 #include "core_v_mini_mcu.h"
 #include "timer_sdk.h"
 #include "x-heep.h"
@@ -21,9 +20,9 @@
 #define PRINTF_IN_SIM   0
 
 /* Error tolerances for the tests. */
-#define CYCLE_TOLERANCE  1         // cycles tolerance for simple timer reads
-#define INTERRUPT_TOLERANCE 50     // cycles tolerance for timer interrupt
-#define TIMER_WAIT_TOLERANCE 30   // cycles tolerance for timer wait
+#define CYCLE_TOLERANCE  2         // cycles tolerance for simple timer reads
+#define INTERRUPT_TOLERANCE 60     // cycles tolerance for timer interrupt
+#define TIMER_WAIT_TOLERANCE 20   // milliseconds tolerance for timer wait
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
@@ -43,12 +42,13 @@ int main(){
     uint32_t i = 0;
     uint32_t timer_cycles;
     uint32_t nop_cycles[4];
-    // Get current Clock Frequency
+
+    // Get current Frequency
     soc_ctrl_t soc_ctrl;
     soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
     uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
 
-    timer_cycles_init();               // Init the timer SDK for clock cycles
+    timer_cycles_init();         // Init the timer SDK for clock cycles
     timer_start();              // Start counting the time
     nop_cycles[0] = timer_stop();  // Stop counting the time
     PRINTF("0 NOPs:\t%d cc\n\r", nop_cycles[0] );
@@ -80,30 +80,30 @@ int main(){
 
     timer_cycles_init();
     timer_irq_enable();
-    timer_arm_start(1000);
-    timer_start();              
+    timer_arm_start(1000);            
     asm volatile ("wfi");       // Wait for interrupt
     timer_cycles = timer_stop();  
     if(abs(timer_cycles-1000) < INTERRUPT_TOLERANCE){ 
-        PRINTF("Timer thershold interrupt working\n" );
+        PRINTF("Timer threshold interrupt working\n" );
     } else {
-        PRINTF("Timer thershold interrupt failed\n\r");
+        PRINTF("Timer threshold interrupt failed\n\r");
         return EXIT_FAILURE;
     }
     
-    timer_microseconds_init();           // Init the timer SDK for microseconds
+    timer_cycles_init();           // Init the timer SDK for microseconds
     timer_start(); 
     for(i = 0; i < 1000; i++){
         asm volatile ("nop");
     }
     timer_cycles = timer_stop();  
-    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", timer_cycles );
+    PRINTF("Microseconds for 1000 NOPs:\t%d μs\n\r", (uint32_t)get_time(timer_cycles) );
 
     PRINTF("Wait 5 seconds\n\r");
-    timer_wait_ms(5000);       // Wait for 5 seconds
-    timer_cycles = timer_stop(); 
+    timer_wait_us(5000000);       // Wait for 5 seconds 
+    timer_cycles = timer_stop();     
     PRINTF("Done\n\r");
-    if(abs(timer_cycles-5000*1000)*(freq_hz/FREQ_1MHz) > TIMER_WAIT_TOLERANCE){ 
+
+    if(abs(timer_cycles-(5*freq_hz)) > TIMER_WAIT_TOLERANCE){ 
         PRINTF("Timer wait failed\n\r");
         return EXIT_FAILURE;
     }
@@ -111,3 +111,4 @@ int main(){
     PRINTF("All tests passed\n\r");
     return EXIT_SUCCESS;
 }
+

--- a/sw/applications/example_timer_sdk/main.c
+++ b/sw/applications/example_timer_sdk/main.c
@@ -15,7 +15,7 @@
 
 /* By default, printfs are activated for FPGA and disabled for simulation. */
 #define PRINTF_IN_FPGA  1
-#define PRINTF_IN_SIM   0
+#define PRINTF_IN_SIM   1
 
 #if TARGET_SIM && PRINTF_IN_SIM
         #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
@@ -25,32 +25,53 @@
     #define PRINTF(...)
 #endif
 
+void __attribute__((aligned(4), interrupt)) handler_irq_timer(void) {
+    timer_arm_stop();
+    timer_irq_clear();
+    return;   
+}
+
 int main(){
     uint8_t i = 0;
-    uint32_t cpu_cycles;
+    uint32_t timer_cycles;
 
     timer_init();               // Init the timer SDK
     timer_start();              // Start counting the time
-    cpu_cycles = timer_stop();  // Stop counting the time
-    PRINTF("0 NOPs:\t%d cc\n\r", cpu_cycles );
+    timer_cycles = timer_stop();  // Stop counting the time
+    PRINTF("0 NOPs:\t%d cc\n\r", timer_cycles );
     
     timer_start();              
     asm volatile ("nop");
-    cpu_cycles = timer_stop();  
-    PRINTF("1 NOP:\t%d cc\n\r", cpu_cycles );
+    timer_cycles = timer_stop();  
+    PRINTF("1 NOP:\t%d cc\n\r", timer_cycles );
     
     timer_start();              
     asm volatile ("nop");
     asm volatile ("nop");
-    cpu_cycles = timer_stop();  
-    PRINTF("2 NOPs:\t%d cc\n\r", cpu_cycles );
+    timer_cycles = timer_stop();  
+    PRINTF("2 NOPs:\t%d cc\n\r", timer_cycles );
 
     timer_start();              
     asm volatile ("nop");
     asm volatile ("nop");
     asm volatile ("nop");
-    cpu_cycles = timer_stop();  
-    PRINTF("3 NOPs:\t%d cc\n\r", cpu_cycles );
-    
+    timer_cycles = timer_stop();  
+    PRINTF("3 NOPs:\t%d cc\n\r", timer_cycles );
+
+    //enable timer interrupt
+    CSR_SET_BITS(CSR_REG_MSTATUS, 0x8);
+    // Set mie.MEIE bit to one to enable machine-level timer interrupts
+    const uint32_t mask = 1 << 7;
+    CSR_SET_BITS(CSR_REG_MIE, mask);
+
+    timer_init();
+    timer_irq_enable();
+    timer_arm_start(10);
+    timer_start();              
+    asm volatile ("wfi");
+    timer_cycles = timer_stop();  
+    PRINTF("wait ARM timer 10 (%d)\n\r", timer_cycles );
+
+
     return EXIT_SUCCESS;
 }

--- a/sw/device/lib/drivers/rv_timer/rv_timer.h
+++ b/sw/device/lib/drivers/rv_timer/rv_timer.h
@@ -105,6 +105,12 @@ typedef enum rv_timer_approximate_tick_params_result {
  * @param[out] out Tick parameters that will approximately produce the desired
  *         counter frequency.
  * @return The result of the operation.
+ * 
+ * The minimum value for `counter_freq` is given by:
+ * counter_freq_min = (255/4096) * clock_freq 
+ * For example, if the clock frequency is 15MHz, the minimum value for `counter_freq` is about
+ * 1 MHz.
+ * The maximum value for `counter_freq` is given by the clock frequency.
  */
 rv_timer_approximate_tick_params_result_t
 rv_timer_approximate_tick_params(uint64_t clock_freq, uint64_t counter_freq,

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -5,8 +5,6 @@
 // File: timer_sdk.c
 // Author: Michele Caon, Francesco Poluzzi
 // Date: 23/07/2024
-// Author: Michele Caon, Francesco Poluzzi
-// Date: 23/07/2024
 // Description: Timer functions
 
 #include <stdint.h>
@@ -21,7 +19,6 @@
 /******************************/
 
 // Timer value
-uint32_t timer_value = 0;
 uint32_t hw_timer_value = 0;
 
 rv_timer_t timer;
@@ -42,7 +39,7 @@ rv_timer_tick_params_t tick_params;
 /* ---- FUNCTION IMPLEMENTATION ---- */
 /*************************************/
 
-uint32_t hw_timer_get_cycles()
+uint32_t timer_get_cycles()
 {
     uint64_t cycle_count;
     rv_timer_counter_read(&timer, 0, &cycle_count);
@@ -59,11 +56,10 @@ void timer_irq_clear()
   rv_timer_irq_clear(&timer, 0, 0);
 }
 
-
 void timer_arm_start(uint32_t threshold)
 {
     rv_timer_arm(&timer, 0, 0, threshold);
-    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
+    timer_start();
 }
 
 void timer_arm_stop()
@@ -71,15 +67,28 @@ void timer_arm_stop()
     rv_timer_counter_set_enabled(&timer, 0, kRvTimerDisabled);
 }
 
-void hw_timer_start()
+
+void timer_arm_set(uint32_t threshold)
 {
-    hw_timer_value = -hw_timer_get_cycles();
+    rv_timer_arm(&timer, 0, 0, threshold);
 }
 
-uint32_t hw_timer_stop()
+void timer_start()
 {
-    hw_timer_value += hw_timer_get_cycles();
-    return hw_timer_value;
+    hw_timer_value = -timer_get_cycles();
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
+}
+
+void timer_reset()
+{
+    rv_timer_reset(&timer);
+}
+
+uint32_t timer_stop()
+{
+    hw_timer_value += timer_get_cycles();
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerDisabled);
+    return  hw_timer_value;
 }
 
 // Initialize the timer
@@ -91,34 +100,23 @@ void timer_cycles_init()
     uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
 
     // Initialize the timer
+    timer_reset();
     rv_timer_init(timer_base, timer_cfg, &timer);
     rv_timer_approximate_tick_params(freq_hz, freq_hz, &tick_params);
     rv_timer_set_tick_params(&timer, 0, tick_params);
-    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
 }
 
 // Initialize the timer
-void  timer_microseconds_init()
+void timer_wait_us(uint32_t us)
 {
     // Get current Frequency
     soc_ctrl_t soc_ctrl;
     soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
     uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
 
-    // Initialize the timer
-    rv_timer_init(timer_base, timer_cfg, &timer);
-    rv_timer_approximate_tick_params(freq_hz, FREQ_1MHz, &tick_params);
-    rv_timer_set_tick_params(&timer, 0, tick_params);
-    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
-}
-
-// Initialize the timer
-void timer_wait_ms(uint32_t ms)
-{
-     timer_microseconds_init();
+    timer_cycles_init();
     timer_irq_enable();
-    timer_arm_start(ms*1000);
-    timer_start();              
+    timer_arm_start(us*(freq_hz/1000000)-50); // 50 cycles for taking into account initialization        
     asm volatile ("wfi");
     timer_irq_clear();
     return;
@@ -131,4 +129,13 @@ void enable_timer_interrupt()
     // Set mie.MEIE bit to one to enable machine-level timer interrupts
     const uint32_t mask = 1 << 7;
     CSR_SET_BITS(CSR_REG_MIE, mask);
+}
+
+float get_time(uint32_t cycles){
+    // Get current Frequency
+    soc_ctrl_t soc_ctrl;
+    soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
+    uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
+
+    return (float)cycles/((float)freq_hz/1000000);
 }

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -19,7 +19,7 @@
 /******************************/
 
 // Timer value
-uint32_t hw_timer_value = 0;
+int32_t hw_timer_value = 0;
 
 rv_timer_t timer;
 
@@ -80,7 +80,8 @@ void timer_start()
 }
 
 void timer_reset()
-{
+{  
+    hw_timer_value = 0;
     rv_timer_reset(&timer);
 }
 

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -131,7 +131,7 @@ void enable_timer_interrupt()
     CSR_SET_BITS(CSR_REG_MIE, mask);
 }
 
-float get_time(uint32_t cycles){
+float get_time_from_cycles(uint32_t cycles){
     // Get current Frequency
     soc_ctrl_t soc_ctrl;
     soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -5,6 +5,8 @@
 // File: timer_sdk.c
 // Author: Michele Caon, Francesco Poluzzi
 // Date: 23/07/2024
+// Author: Michele Caon, Francesco Poluzzi
+// Date: 23/07/2024
 // Description: Timer functions
 
 #include <stdint.h>
@@ -81,7 +83,7 @@ uint32_t hw_timer_stop()
 }
 
 // Initialize the timer
-void timer_init()
+void timer_cycles_init()
 {
     // Get current Frequency
     soc_ctrl_t soc_ctrl;
@@ -96,7 +98,7 @@ void timer_init()
 }
 
 // Initialize the timer
-void timer_init_us()
+void  timer_microseconds_init()
 {
     // Get current Frequency
     soc_ctrl_t soc_ctrl;
@@ -105,7 +107,7 @@ void timer_init_us()
 
     // Initialize the timer
     rv_timer_init(timer_base, timer_cfg, &timer);
-    rv_timer_approximate_tick_params(freq_hz, FREQ_US, &tick_params);
+    rv_timer_approximate_tick_params(freq_hz, FREQ_1MHz, &tick_params);
     rv_timer_set_tick_params(&timer, 0, tick_params);
     rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
 }
@@ -113,7 +115,7 @@ void timer_init_us()
 // Initialize the timer
 void timer_wait_ms(uint32_t ms)
 {
-    timer_init_us();
+     timer_microseconds_init();
     timer_irq_enable();
     timer_arm_start(ms*1000);
     timer_start();              

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -11,6 +11,8 @@
 
 #include "timer_sdk.h"
 #include "csr.h"
+#include "soc_ctrl.h"
+
 
 /******************************/
 /* ---- GLOBAL VARIABLES ---- */
@@ -33,6 +35,8 @@ mmio_region_t timer_base = {
 
 rv_timer_tick_params_t tick_params;
 
+static const uint64_t kTickFreqHz = 1000 * 1000; // 1 MHz
+
 /*************************************/
 /* ---- FUNCTION IMPLEMENTATION ---- */
 /*************************************/
@@ -40,9 +44,14 @@ rv_timer_tick_params_t tick_params;
 // Initialize the hardware timer
 void hw_timer_init()
 {
+    // Get current Frequency
+    soc_ctrl_t soc_ctrl;
+    soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
+    uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
+
     // Initialize the timer
     rv_timer_init(timer_base, timer_cfg, &timer);
-    rv_timer_approximate_tick_params(REFERENCE_CLOCK_Hz, REFERENCE_CLOCK_Hz, &tick_params);
+    rv_timer_approximate_tick_params(freq_hz, kTickFreqHz, &tick_params);
     rv_timer_set_tick_params(&timer, 0, tick_params);
     rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
 }
@@ -52,6 +61,28 @@ uint32_t hw_timer_get_cycles()
     uint64_t cycle_count;
     rv_timer_counter_read(&timer, 0, &cycle_count);
     return (uint32_t)cycle_count;
+}
+
+void timer_irq_enable()
+{
+  rv_timer_irq_enable(&timer, 0, 0, kRvTimerEnabled);
+}
+
+void timer_irq_clear()
+{
+  rv_timer_irq_clear(&timer, 0, 0);
+}
+
+
+void timer_arm_start(uint32_t threshold)
+{
+    rv_timer_arm(&timer, 0, 0, threshold);
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
+}
+
+void timer_arm_stop()
+{
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerDisabled);
 }
 
 void hw_timer_start()
@@ -69,5 +100,5 @@ uint32_t hw_timer_stop()
 void timer_init()
 {
     // Enable MCYCLE counter
-    CSR_CLEAR_BITS(CSR_REG_MCOUNTINHIBIT, 0x1);
+    hw_timer_init();
 }

--- a/sw/device/lib/sdk/timer/timer_sdk.c
+++ b/sw/device/lib/sdk/timer/timer_sdk.c
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
 // File: timer_sdk.c
-// Author: Michele Caon
-// Date: 31/07/2023
+// Author: Michele Caon, Francesco Poluzzi
+// Date: 23/07/2024
 // Description: Timer functions
 
 #include <stdint.h>
@@ -35,26 +35,10 @@ mmio_region_t timer_base = {
 
 rv_timer_tick_params_t tick_params;
 
-static const uint64_t kTickFreqHz = 1000 * 1000; // 1 MHz
 
 /*************************************/
 /* ---- FUNCTION IMPLEMENTATION ---- */
 /*************************************/
-
-// Initialize the hardware timer
-void hw_timer_init()
-{
-    // Get current Frequency
-    soc_ctrl_t soc_ctrl;
-    soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
-    uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
-
-    // Initialize the timer
-    rv_timer_init(timer_base, timer_cfg, &timer);
-    rv_timer_approximate_tick_params(freq_hz, kTickFreqHz, &tick_params);
-    rv_timer_set_tick_params(&timer, 0, tick_params);
-    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
-}
 
 uint32_t hw_timer_get_cycles()
 {
@@ -99,6 +83,50 @@ uint32_t hw_timer_stop()
 // Initialize the timer
 void timer_init()
 {
-    // Enable MCYCLE counter
-    hw_timer_init();
+    // Get current Frequency
+    soc_ctrl_t soc_ctrl;
+    soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
+    uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
+
+    // Initialize the timer
+    rv_timer_init(timer_base, timer_cfg, &timer);
+    rv_timer_approximate_tick_params(freq_hz, freq_hz, &tick_params);
+    rv_timer_set_tick_params(&timer, 0, tick_params);
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
+}
+
+// Initialize the timer
+void timer_init_us()
+{
+    // Get current Frequency
+    soc_ctrl_t soc_ctrl;
+    soc_ctrl.base_addr = mmio_region_from_addr((uintptr_t)SOC_CTRL_START_ADDRESS);
+    uint32_t freq_hz = soc_ctrl_get_frequency(&soc_ctrl);
+
+    // Initialize the timer
+    rv_timer_init(timer_base, timer_cfg, &timer);
+    rv_timer_approximate_tick_params(freq_hz, FREQ_US, &tick_params);
+    rv_timer_set_tick_params(&timer, 0, tick_params);
+    rv_timer_counter_set_enabled(&timer, 0, kRvTimerEnabled);
+}
+
+// Initialize the timer
+void timer_wait_ms(uint32_t ms)
+{
+    timer_init_us();
+    timer_irq_enable();
+    timer_arm_start(ms*1000);
+    timer_start();              
+    asm volatile ("wfi");
+    timer_irq_clear();
+    return;
+}
+
+void enable_timer_interrupt()
+{
+    //enable timer interrupt
+    CSR_SET_BITS(CSR_REG_MSTATUS, 0x8);
+    // Set mie.MEIE bit to one to enable machine-level timer interrupts
+    const uint32_t mask = 1 << 7;
+    CSR_SET_BITS(CSR_REG_MIE, mask);
 }

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
 // File: timer_sdk.h
-// Authors: Michele Caon, Luigi Giuffrida
-// Date: 31/07/2023
+// Authors: Michele Caon, Luigi Giuffrida, Francesco Poluzzi
+// Date: 23/07/2024
 // Description: Execution time measurements utilities
 
 #ifndef TIMER_SDK_H_
@@ -20,6 +20,7 @@
 #include "x-heep.h"
 
 #define TICK_FREQ 1000000
+#define FREQ_US 1000000
 
 /******************************/
 /* ---- GLOBAL VARIABLES ---- */
@@ -34,12 +35,6 @@ extern rv_timer_t timer;
 /********************************/
 /* ---- EXPORTED FUNCTIONS ---- */
 /********************************/
-
-/**
- * @brief Initialize the hardware timer
- * 
- */
-void hw_timer_init();
 
 /**
  * @brief Get the current value of the HW timer
@@ -63,10 +58,16 @@ uint32_t hw_timer_stop();
 
 
 /**
- * @brief Initialize the timer
+ * @brief Initialize the timer for counting clock cycles
  * 
  */
 void timer_init();
+
+/**
+ * @brief Initialize the timer for counting microseconds
+ * 
+ */
+void timer_init_us();
 
 /**
  * @brief Get the current value of the MCYCLE CSR
@@ -115,5 +116,17 @@ void timer_arm_start(uint32_t threshold);
  * @brief Stop to output when timer is greater than or equal to threshold previously set
  */
 void timer_arm_stop();
+
+/**
+ * @brief Wait for a certain amount of milliseconds. Not precise with small
+ * numbers of milliseconds. 
+ * You need to enable timer interrupts with enable_timer_interrupt() before using this function
+ */
+void timer_wait_ms(uint32_t ms);
+
+/**
+ * @brief Enable the timer machine-level interrupts for X-Heep
+ */
+void enable_timer_interrupt();
 
 #endif /* TIMER_SDK_H_ */

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -6,8 +6,6 @@
 // File: timer_sdk.h
 // Authors: Michele Caon, Luigi Giuffrida, Francesco Poluzzi
 // Date: 23/07/2024
-// Authors: Michele Caon, Luigi Giuffrida, Francesco Poluzzi
-// Date: 23/07/2024
 // Description: Execution time measurements utilities
 
 #ifndef TIMER_SDK_H_
@@ -29,7 +27,6 @@
 /******************************/
 
 // Timer value
-extern uint32_t timer_value;
 extern uint32_t hw_timer_value;
 
 extern rv_timer_t timer;
@@ -43,21 +40,26 @@ extern rv_timer_t timer;
  * 
 * @return int64_t Current value of the HW timer
  */
-uint32_t hw_timer_get_cycles();
+uint32_t timer_get_cycles();
 
 /**
- * @brief Start the HW timer
+ * @brief Start the timer
  * 
  */
-void hw_timer_start();
+void timer_start();
+
+/**
+ * @brief Stop and reset the timer to 0
+ * 
+ */
+void timer_reset();
 
 /**
  * @brief Stop the HW timer
  * 
  * @return int64_t Elapsed time in clock cycles
  */
-uint32_t hw_timer_stop();
-
+uint32_t timer_stop();
 
 /**
  * @brief Initialize the timer for counting clock cycles
@@ -65,40 +67,6 @@ uint32_t hw_timer_stop();
  * 
  */
 void timer_cycles_init();
-
-/**
- * @brief Initialize the timer for counting microseconds
- * 
- */
-void  timer_microseconds_init();
-
-/**
- * @brief Get the current value of the MCYCLE CSR
- * 
- * @return int64_t Current value of the MCYCLE CSR
- */
-inline uint32_t timer_get_cycles() {
-    uint32_t cycle_count;
-    CSR_READ(CSR_REG_MCYCLE, &cycle_count);
-    return cycle_count;
-}
-
-/**
- * @brief Start the timer
- * 
- */
-inline void timer_start() {
-    hw_timer_start();
-}
-
-/**
- * @brief Stop the timer
- * 
- * @return int64_t Elapsed time in clock cycles
- */
-inline uint32_t timer_stop() {
-    return hw_timer_stop();
-}
 
 /**
  * @brief Enable the timer IRQ
@@ -112,6 +80,7 @@ void timer_irq_clear();
 
 /**
  * @brief Arms the timer to go off once the counter value is greater than or equal to threshold
+ * and starts the timer
  */
 void timer_arm_start(uint32_t threshold);
 
@@ -121,11 +90,10 @@ void timer_arm_start(uint32_t threshold);
 void timer_arm_stop();
 
 /**
- * @brief Wait for a certain amount of milliseconds. Not precise with small
- * numbers of milliseconds. 
- * You need to enable timer interrupts with enable_timer_interrupt() before using this function
+ * @brief Set the timer to go off once the counter value is greater than or equal to threshold,
+ * without starting the timer
  */
-void timer_wait_ms(uint32_t ms);
+void timer_arm_set(uint32_t threshold);
 
 /**
  * @brief Enable the timer machine-level interrupts for X-Heep
@@ -133,15 +101,21 @@ void timer_wait_ms(uint32_t ms);
 void enable_timer_interrupt();
 
 /**
- * @brief Wait for a certain amount of milliseconds. Not precise with small
- * numbers of milliseconds. 
+ * @brief Wait for a certain amount of microseconds. 
  * You need to enable timer interrupts with enable_timer_interrupt() before using this function
  */
-void timer_wait_ms(uint32_t ms);
+void timer_wait_us(uint32_t ms);
 
 /**
  * @brief Enable the timer machine-level interrupts for X-Heep
  */
 void enable_timer_interrupt();
+
+/**
+ * @brief Get the time taken to execute a certain number of cycles
+ * 
+ * @return float value representing the time taken in microseconds
+ */
+float get_time(uint32_t cycles);
 
 #endif /* TIMER_SDK_H_ */

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -116,6 +116,6 @@ void enable_timer_interrupt();
  * 
  * @return float value representing the time taken in microseconds
  */
-float get_time(uint32_t cycles);
+float get_time_from_cycles(uint32_t cycles);
 
 #endif /* TIMER_SDK_H_ */

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -84,7 +84,7 @@ inline uint32_t timer_get_cycles() {
  * 
  */
 inline void timer_start() {
-    timer_value = -timer_get_cycles();
+    hw_timer_start();
 }
 
 /**
@@ -93,8 +93,27 @@ inline void timer_start() {
  * @return int64_t Elapsed time in clock cycles
  */
 inline uint32_t timer_stop() {
-    timer_value += timer_get_cycles();
-    return timer_value;
+    return hw_timer_stop();
 }
+
+/**
+ * @brief Enable the timer IRQ
+ */
+void timer_irq_enable();
+
+/**
+ * @brief Clear the timer IRQ
+ */
+void timer_irq_clear();
+
+/**
+ * @brief Arms the timer to go off once the counter value is greater than or equal to threshold
+ */
+void timer_arm_start(uint32_t threshold);
+
+/**
+ * @brief Stop to output when timer is greater than or equal to threshold previously set
+ */
+void timer_arm_stop();
 
 #endif /* TIMER_SDK_H_ */

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -27,7 +27,7 @@
 /******************************/
 
 // Timer value
-extern uint32_t hw_timer_value;
+extern int32_t hw_timer_value;
 
 extern rv_timer_t timer;
 

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -1,8 +1,11 @@
+
 // Copyright 2023 EPFL and Politecnico di Torino.
 // Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
 // File: timer_sdk.h
+// Authors: Michele Caon, Luigi Giuffrida, Francesco Poluzzi
+// Date: 23/07/2024
 // Authors: Michele Caon, Luigi Giuffrida, Francesco Poluzzi
 // Date: 23/07/2024
 // Description: Execution time measurements utilities
@@ -20,7 +23,7 @@
 #include "x-heep.h"
 
 #define TICK_FREQ 1000000
-#define FREQ_US 1000000
+#define FREQ_1MHz 1000000
 
 /******************************/
 /* ---- GLOBAL VARIABLES ---- */
@@ -59,15 +62,16 @@ uint32_t hw_timer_stop();
 
 /**
  * @brief Initialize the timer for counting clock cycles
+ * @brief Initialize the timer for counting clock cycles
  * 
  */
-void timer_init();
+void timer_cycles_init();
 
 /**
  * @brief Initialize the timer for counting microseconds
  * 
  */
-void timer_init_us();
+void  timer_microseconds_init();
 
 /**
  * @brief Get the current value of the MCYCLE CSR
@@ -116,6 +120,18 @@ void timer_arm_start(uint32_t threshold);
  * @brief Stop to output when timer is greater than or equal to threshold previously set
  */
 void timer_arm_stop();
+
+/**
+ * @brief Wait for a certain amount of milliseconds. Not precise with small
+ * numbers of milliseconds. 
+ * You need to enable timer interrupts with enable_timer_interrupt() before using this function
+ */
+void timer_wait_ms(uint32_t ms);
+
+/**
+ * @brief Enable the timer machine-level interrupts for X-Heep
+ */
+void enable_timer_interrupt();
 
 /**
  * @brief Wait for a certain amount of milliseconds. Not precise with small

--- a/sw/device/lib/sdk/timer/timer_sdk.h
+++ b/sw/device/lib/sdk/timer/timer_sdk.h
@@ -22,7 +22,6 @@
 #include "core_v_mini_mcu.h"
 #include "x-heep.h"
 
-#define TICK_FREQ 1000000
 #define FREQ_1MHz 1000000
 
 /******************************/


### PR DESCRIPTION
 - Fixed timer SDK (that was not working in WFI). 
 - Added timer function for inirtializing timer to measure time in microseconds instead of cycles .
 - Added fuction for waiting a specific amount of time. 
 - Added function for enabling timer interrupts.
 - Extended example_timer_sdk application.