### PR TITLE
Add functionalities to flash bsp

### DIFF
--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -60,7 +60,7 @@ extern "C"
 /**
  * Returns the mask to enable/disable DMA interrupts.
  */
-#define DMA_CSR_REG_MIE_MASK (( 1 << 19 ) | (1 << 11 ) ) // @ToDo Add definitions for this 19 and 11
+#define DMA_CSR_REG_MIE_MASK (( 1 << 19 )) // 19 is DMA fast interrupt bit in MIE CSR
 
 /**
  * Mask to determine if an address is multiple of 4 (Word aligned).


### PR DESCRIPTION
This PR includes many features and fixes (still adding):

- When DMA is used in polling, as in the FLASH bsp, the DMA hal disables all the interrupts (bit 11 of MIE CSR) without re-enabling them, the fix prevent this to happen disabling only the DMA interrupts (bit 19 of the the MIE CSR). The DMA interrupts are still to be re-enabled at application level. @JoseCalero @JuanSapriza 
- ...