### PR TITLE
Fix `cv32e40x` hanging on `fence.i` instructions

### DIFF
--- a/hw/core-v-mini-mcu/cpu_subsystem.sv
+++ b/hw/core-v-mini-mcu/cpu_subsystem.sv
@@ -183,7 +183,7 @@ module cpu_subsystem
 
         // Fence.i flush handshake
         .fencei_flush_req_o(),
-        .fencei_flush_ack_i(1'b0),
+        .fencei_flush_ack_i(1'b1),
 
         // Debug interface
         .debug_req_i      (debug_req_i),


### PR DESCRIPTION
## Motivation

The `cv32e40x` core within X-HEEP currently hangs on all `fence.i` instructions. This issue arises because `fence.i` instructions wait for an external handshake signal (`fencei_flush_ack_i`) before proceeding to commit the instruction. According to `cv32e40x` [documentation](https://docs.openhwgroup.org/projects/cv32e40x-user-manual/en/latest/fencei.html):

> It is recommended to tie `fencei_flush_ack_i` to 1 in order to avoid stalling fence.i instructions indefinitely.

However, in X-HEEP, such signal is tied to 0.

This behavior creates a critical problem when using GDB, as `fence.i` instructions are sent when establishing a new connection with the core. A stalled `fence.i `instruction causes the core to hang, leading to a timeout in the remote connection and ultimately causing the debugger to fail.

## Reproducing the issue
- Pull the latest version of X-HEEP.
- Set `cv32e40x` as the Host CPU, then generate and build the project.
- Connect to the core using GDB following the [debugging guide](https://x-heep.readthedocs.io/en/latest/How_to/Debug.html).
- Observe the `Ignoring packet error` message in the GDB terminal, indicating that the connection timed out because the `cv32e40x` core is stalled.

## Fix
The proposed fix resolves the stalling issue, allowing the `cv32e40x` core to operate correctly without hanging during fence.i instructions. With this fix, the GDB connection does not time out. 
The solution has been tested in both simulation and on the FPGA target device `zcu104`.
