### PR TITLE
Makefile: remove superfluous `@` after `\`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,11 +156,11 @@ verible:
 app: clean-app
 	@$(MAKE) -C sw PROJECT=$(PROJECT) TARGET=$(TARGET) LINKER=$(LINKER) LINK_FOLDER=$(LINK_FOLDER) COMPILER=$(COMPILER) COMPILER_PREFIX=$(COMPILER_PREFIX) ARCH=$(ARCH) SOURCE=$(SOURCE) \
 	|| { \
-	@echo "\033[0;31mHmmm... seems like the compilation failed...\033[0m"; \
-	@echo "\033[0;31mIf you do not understand why, it is likely that you either:\033[0m"; \
-	@echo "\033[0;31m  a) offended the Leprechaun of Electronics\033[0m"; \
-	@echo "\033[0;31m  b) forgot to run make mcu-gen\033[0m"; \
-	@echo "\033[0;31mI would start by checking b) if I were you!\033[0m"; \
+	echo "\033[0;31mHmmm... seems like the compilation failed...\033[0m"; \
+	echo "\033[0;31mIf you do not understand why, it is likely that you either:\033[0m"; \
+	echo "\033[0;31m  a) offended the Leprechaun of Electronics\033[0m"; \
+	echo "\033[0;31m  b) forgot to run make mcu-gen\033[0m"; \
+	echo "\033[0;31mI would start by checking b) if I were you!\033[0m"; \
 	exit 1; \
 	}
 


### PR DESCRIPTION
Remove superfluous `@` in Makefile recipe lines that are split into multiple lines using `\`:  only the first line should start with `@` and it will apply to all the lines in the multi-line "recipe line"; if any other line in the "recipe line" starts with `@` it will be considered as part of the command, resulting in errors such as `/bin/sh: 3: @echo: not found`.

https://www.gnu.org/software/make/manual/html_node/Splitting-Recipe-Lines.html

As a side note, it might be a good idea to indent all the "continuation lines" in Makefile recipes with one extra tab to make it visually clear that it's all part of a single block, and that an `@` on the first line affects the entire block.  (Vim seems to add that indentation by default so it's probably not a bad idea to follow that convention.)