### PR TITLE
Made the spi signals tri state

### DIFF
--- a/tb/testharness.sv
+++ b/tb/testharness.sv
@@ -77,13 +77,28 @@ module testharness #(
   wire mux_jtag_trstn;
   wire [31:0] gpio;
 
-  wire [3:0] spi_flash_sd_io;
-  wire [1:0] spi_flash_csb;
-  wire spi_flash_sck;
+`ifndef VERILATOR
+  // Pull-up/down are needed in Questasim
+  // SPI flash
+  tri0       spi_flash_sck;
+  tri1 [1:0] spi_flash_csb;
+  tri0 [3:0] spi_flash_sd_io;
 
-  wire [3:0] spi_sd_io;
+  // SPI
+  tri0       spi_sck;
+  tri1 [1:0] spi_csb;
+  tri0 [3:0] spi_sd_io;
+`else
+  // SPI flash
+  wire       spi_flash_sck;
+  wire [1:0] spi_flash_csb;
+  wire [3:0] spi_flash_sd_io;
+
+  // SPI
+  wire       spi_sck;
   wire [1:0] spi_csb;
-  wire spi_sck;
+  wire [3:0] spi_sd_io;
+`endif
 
   logic [EXT_PERIPHERALS_PORT_SEL_WIDTH-1:0] ext_periph_select;
 


### PR DESCRIPTION
In verilator 4 that the SPI signals are not driven is not an issue.
In Questasim rtl simulation it is also not an issue. 
However, in Questasim post-synthesis (and probably also in Verilator 5), the fact that some signals are not driven (which is the case of the QSPI data, which are left as input on both sides --master and slave--). 

The solution I found is to set them as tri-state and pull them up to 0 or 1. That was shown to work on Questasim for HEEPidermis. This should not affect the behavior on Verilator (as it is done inside a `ifndef)

![image](https://github.com/user-attachments/assets/09bd96a7-241a-4578-8bcd-9b2a35ca92ba)
Weak low signal that then is driven by the SPI master and actually acquires a value. 

   