### PR TITLE
Add constant_attribute for pads

### DIFF
--- a/hw/system/pad_control/data/pad_control.hjson.tpl
+++ b/hw/system/pad_control/data/pad_control.hjson.tpl
@@ -25,6 +25,7 @@
 % if pads_attributes != None:
 % for pad in total_pad_list:
 % if pad.pad_type == 'input' or pad.pad_type == 'output' or pad.pad_type == 'inout':
+% if pad.constant_attribute == False:
     { name:     "PAD_ATTRIBUTE_${pad.name.upper()}",
       desc:     "${pad.name} Attributes (Pull Up En, Pull Down En, etc. It is technology specific.",
       resval:   "${pads_attributes['resval']}"
@@ -34,6 +35,7 @@
         { bits: "${pads_attributes['bits']}", name: "PAD_ATTRIBUTE_${pad.name.upper()}", desc: "Pad Attribute ${pad.name.upper()} Reg" }
       ]
     }
+% endif
 % endif
 % endfor
 % endif

--- a/hw/system/pad_control/rtl/pad_control.sv.tpl
+++ b/hw/system/pad_control/rtl/pad_control.sv.tpl
@@ -67,7 +67,11 @@ module pad_control #(
 % if pads_attributes != None:
 % for pad in total_pad_list:
 % if pad.pad_type == 'input' or pad.pad_type == 'output' or pad.pad_type == 'inout':
+% if pad.constant_attribute == False:
   assign pad_attributes_o[${pad.localparam}] = reg2hw.pad_attribute_${pad.name.lower()}.q;
+% else:
+  assign pad_attributes_o[${pad.localparam}] = ${int(pads_attributes['resval'], 16)};
+% endif
 % endif
 % endfor
 % endif

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -210,7 +210,7 @@ class Pad:
         self.pad_ring_bonding_bonding += '    .' + self.signal_name + 'oe_i(' + oe_internal_signals + '),'
         self.x_heep_system_interface += '    inout wire ' + self.signal_name + 'io,'
 
-  def __init__(self, name, cell_name, pad_type, pad_mapping, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, has_attribute, attribute_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip):
+  def __init__(self, name, cell_name, pad_type, pad_mapping, index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, has_attribute, attribute_bits, constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip):
 
     self.name = name
     self.cell_name = cell_name
@@ -229,6 +229,7 @@ class Pad:
 
     self.has_attribute = has_attribute
     self.attribute_bits = int(attribute_bits.split(":")[0]) - int(attribute_bits.split(":")[1]) + 1
+    self.constant_attribute = constant_attribute
 
     self.signal_name_drive = []
     self.pad_type_drive    = []
@@ -819,6 +820,14 @@ def main():
             pad_keep_internal = False
 
         try:
+            if pads[key]['constant_attribute'] == 'True':
+                pad_constant_attribute = True
+            else:
+                pad_constant_attribute = False
+        except KeyError:
+            pad_constant_attribute = False
+
+        try:
             pad_layout_orient = pads[key]['layout_attributes']['orient']
         except KeyError:
             pad_layout_orient = None
@@ -873,13 +882,13 @@ def main():
             except KeyError:
                 pad_skip_declaration_mux = False
 
-            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+            p = Pad(pad_mux, '', pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
             pad_mux_list.append(p)
 
         if pad_num > 1:
             for p in range(pad_num):
                 pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+                pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
                 if not pad_keep_internal:
                     pad_obj.create_pad_ring()
                 pad_obj.create_core_v_mini_mcu_ctrl()
@@ -898,7 +907,7 @@ def main():
 
         else:
             pad_cell_name = "pad_" + key + "_i"
-            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+            pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, pad_index_counter, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
             if not pad_keep_internal:
                 pad_obj.create_pad_ring()
             pad_obj.create_core_v_mini_mcu_ctrl()
@@ -1014,13 +1023,13 @@ def main():
                 except KeyError:
                     pad_skip_declaration_mux = False
 
-                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+                p = Pad(pad_mux, '', external_pads[key]['mux'][pad_mux]['type'], pad_mapping, 0, pad_active_mux, pad_driven_manually_mux, pad_skip_declaration_mux, [], pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
                 pad_mux_list.append(p)
 
             if pad_num > 1:
                 for p in range(pad_num):
                     pad_cell_name = "pad_" + key + "_" + str(p+pad_offset) + "_i"
-                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+                    pad_obj = Pad(pad_name + "_" + str(p+pad_offset), pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
                     pad_obj.create_pad_ring()
                     pad_obj.create_pad_ring_bonding()
                     pad_obj.create_internal_signals()
@@ -1036,7 +1045,7 @@ def main():
 
             else:
                 pad_cell_name = "pad_" + key + "_i"
-                pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
+                pad_obj = Pad(pad_name, pad_cell_name, pad_type, pad_mapping, external_pad_index, pad_active, pad_driven_manually, pad_skip_declaration, pad_mux_list, pads_attributes!=None, pads_attributes_bits, pad_constant_attribute, pad_layout_index, pad_layout_orient, pad_layout_cell, pad_layout_bondpad, pad_layout_offset, pad_layout_skip)
                 pad_obj.create_pad_ring()
                 pad_obj.create_pad_ring_bonding()
                 pad_obj.create_internal_signals()


### PR DESCRIPTION
## Description
Add the optional `constant_attribute` parameter to pad description in pads HJSON description. When this parameter is defined, no configuration register for the pad is instantiated. This prevents timing loops on pads connected to clock sources or modifying the active clock source (e.g., external reference clock or FLL-generated clock).