### PR TITLE
Simplify kwargs

### DIFF
--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -19,6 +19,7 @@ from mako.template import Template
 import collections
 from math import log2
 import x_heep_gen.load_config
+from x_heep_gen.load_config import load_peripherals_config
 from x_heep_gen.system import BusType
 import x_heep_gen.peripherals.base_peripherals
 import x_heep_gen.peripherals.user_peripherals
@@ -875,9 +876,9 @@ def main():
         exit(
             "external_domains must be less than 32 instead of " + str(external_domains)
         )
- 
+
     try:
-        has_spi_slave = 1 if obj['debug']['has_spi_slave'] == "yes" else 0
+        has_spi_slave = 1 if obj["debug"]["has_spi_slave"] == "yes" else 0
     except KeyError:
         has_spi_slave = 0
 
@@ -885,198 +886,44 @@ def main():
         pathlib.PurePath(str(args.config)), config_override
     )
 
+    load_peripherals_config(xheep, args.cfg_peripherals.name)
+
     debug_start_address = string2int(obj["debug"]["address"])
     if int(debug_start_address, 16) < int("10000", 16):
         exit("debug start address must be greater than 0x10000")
 
     debug_size_address = string2int(obj["debug"]["length"])
 
-    if xheep.are_base_peripherals_configured():
-        base_peripheral_start_address = xheep.get_base_peripherals_base_address()
-        base_peripheral_size_address = xheep.get_base_peripherals_length()
-    else:
-        base_peripheral_start_address = int(
-            string2int(obj["ao_peripherals"]["address"]), 16
-        )
-        base_peripheral_size_address = int(
-            string2int(obj["ao_peripherals"]["length"]), 16
-        )
-
-    if base_peripheral_start_address < int("10000", 16):
+    if xheep.get_base_peripherals_base_address() < int("10000", 16):
         exit("always on peripheral start address must be greater than 0x10000")
 
-    def extract_peripherals(
-        peripherals,
-    ):  # TODO : Remove when peripherals configured only through python config() (are_peripherals_configured removed)
-        result = {}
-        for name, info in peripherals.items():
-            if isinstance(info, dict):
-                new_info = {}
-                for k, v in info.items():
-                    if k != "is_included":
-                        new_info[k] = string2int(v)
-                    else:
-                        new_info[k] = v
-                result[name] = new_info
+    dma = xheep.get_dma()[0]  # Assuming there is only one DMA peripheral
 
-        return result
-
-    def discard_path(
-        peripherals,
-    ):  # TODO : Remove when peripherals configured only through python config() (are_peripherals_configured removed)
-        new = {}
-        for k, v in peripherals.items():
-            if isinstance(v, dict):
-                new[k] = {key: val for key, val in v.items() if key not in ("path")}
-            else:
-                new[k] = v
-        return new
-
-    def len_extracted_peripherals(
-        peripherals,
-    ):  # TODO : Remove when peripherals configured only through python config() (are_peripherals_configured removed)
-        len_ep = 0
-        for name, info in peripherals.items():
-            if isinstance(info, dict):
-                if info["is_included"] == "yes":
-                    len_ep += 1
-        return len_ep
-
-    if xheep.are_base_peripherals_configured():
-        base_peripherals = xheep.get_base_peripherals()  # Paths still in peripherals
-        base_peripherals_count = len(base_peripherals)
-        dma = xheep.get_dma()[
-            0
-        ]  # TODO : Currently considering that there is only one DMA peripheral
-        dma_ch_count = dma.get_num_channels()
-        dma_ch_size = dma.get_ch_length()
-        # Number of master ports for the dma subsystem
-        num_dma_master_ports = dma.get_num_master_ports()
-        # Number of masters for each slave of the DMA NtoM xbar
-        num_dma_xbar_channels_per_master_port = dma.get_num_channels_per_master_port()
-    else:
-        base_peripherals = extract_peripherals(discard_path(obj["ao_peripherals"]))
-        base_peripherals_count = len(base_peripherals)
-        dma_ch_count = int(base_peripherals["dma"]["num_channels"])
-        dma_ch_size = int(base_peripherals["dma"]["ch_length"])
-        # Number of master ports for the dma subsystem
-        num_dma_master_ports = int(base_peripherals["dma"]["num_master_ports"])
-        # Number of masters for each slave of the DMA NtoM xbar
-        num_dma_xbar_channels_per_master_port = int(
-            base_peripherals["dma"]["num_channels_per_master_port"]
-        )
-
-    if dma_ch_count > 256 or dma_ch_count == 0:
+    if dma.get_num_channels() > 256 or dma.get_num_channels() == 0:
         exit("Number of DMA channels has to be between 0 and 256, excluded")
 
-    if num_dma_master_ports > dma_ch_count or num_dma_master_ports == 0:
+    if (
+        dma.get_num_master_ports() > dma.get_num_channels()
+        or dma.get_num_master_ports() == 0
+    ):
         exit(
             "Number of DMA master ports has to be between 0 and "
-            + str(dma_ch_count)
+            + str(dma.get_num_channels())
             + ", 0 excluded"
         )
 
     if (
-        num_dma_xbar_channels_per_master_port > dma_ch_count and dma_ch_count != 1
-    ) or num_dma_xbar_channels_per_master_port == 0:
+        dma.get_num_channels_per_master_port() > dma.get_num_channels()
+        and dma.get_num_channels() != 1
+    ) or dma.get_num_channels_per_master_port() == 0:
         exit(
             "Number of DMA channels per system bus master ports has to be between 0 and "
-            + str(dma_ch_count)
+            + str(dma.get_num_channels())
             + ", excluded"
         )
 
-    if num_dma_master_ports > 1:
-        # Computation of full_masters_xbars
-        temp_full_masters_xbars = math.floor(
-            dma_ch_count / num_dma_xbar_channels_per_master_port
-        )
-        if (
-            temp_full_masters_xbars < num_dma_master_ports
-            and temp_full_masters_xbars * num_dma_xbar_channels_per_master_port
-            == dma_ch_count
-        ):
-            full_masters_xbars = temp_full_masters_xbars - 1
-        else:
-            full_masters_xbars = temp_full_masters_xbars
-        last = num_dma_xbar_channels_per_master_port * full_masters_xbars
-
-        # Array initialization
-        array_xbar_gen = [0] * num_dma_master_ports
-
-        # Computation of the number of xbar channels for each master port
-        for i in range(num_dma_master_ports):
-            if i < full_masters_xbars:
-                array_xbar_gen[i] = num_dma_xbar_channels_per_master_port
-            else:
-                array_xbar_gen[i] = min(
-                    dma_ch_count - last,
-                    dma_ch_count - last - (num_dma_master_ports - i - 1),
-                )
-                last = last + array_xbar_gen[i]
-
-        if sum(array_xbar_gen) != dma_ch_count or 0 in array_xbar_gen:
-            exit("Error in the DMA xbar generation: wrong parameters")
-
-        dma_xbar_array = ", ".join(map(str, array_xbar_gen))
-    else:
-        if num_dma_xbar_channels_per_master_port != dma_ch_count:
-            exit(
-                "With 1 master port, the number of DMA channels per master port has to be equal to the number of DMA channels"
-            )
-        dma_xbar_array = "default: 1"
-
-    if xheep.are_user_peripherals_configured():
-        user_peripheral_start_address = xheep.get_user_peripherals_base_address()
-        user_peripheral_size_address = xheep.get_user_peripherals_length()
-        user_peripherals = xheep.get_user_peripherals()  # Paths still in peripherals
-        user_peripherals_count = len(user_peripherals)
-    else:
-        user_peripheral_start_address = int(
-            string2int(obj["peripherals"]["address"]), 16
-        )
-        user_peripheral_size_address = int(string2int(obj["peripherals"]["length"]), 16)
-        user_peripherals = extract_peripherals(discard_path(obj["peripherals"]))
-        user_peripherals_count = len(user_peripherals)
-
-    if user_peripheral_start_address < int("10000", 16):
+    if xheep.get_user_peripherals_base_address() < int("10000", 16):
         exit("user peripheral start address must be greater than 0x10000")
-
-    # For simplicity between python config and hjson config, formating peripherals to list of dictionaries instead of list of Peripherals
-    def __format_peripherals_to_dicts(peripherals):
-        format = {}
-
-        for p in peripherals:
-            description = {
-                "offset": f"{p.get_address() & 0xFFFFFFFF:08X}",  # Converts int to its hexadecimal representation on 8 digits
-                "length": f"{p.get_length() & 0xFFFFFFFF:08X}",
-                # Doesn't add path since it's filtered out with hjson config version
-            }
-
-            # Adding DMA specific information
-            if isinstance(p, x_heep_gen.peripherals.base_peripherals.DMA):
-                description["ch_length"] = hex(p.get_ch_length()).split("x")[
-                    1
-                ]  # Converts int to its hexadecimal representation (minimal number of digits)
-                description["num_channels"] = hex(p.get_num_channels()).split("x")[1]
-                description["num_master_ports"] = hex(p.get_num_master_ports()).split(
-                    "x"
-                )[1]
-                description["num_channels_per_master_port"] = hex(
-                    p.get_num_channels_per_master_port()
-                ).split("x")[1]
-
-            # Adding is_included to the description if the peripheral is a UserPeripheral
-            if isinstance(p, x_heep_gen.peripherals.abstractions.UserPeripheral):
-                description["is_included"] = "yes"
-
-            format[p.get_name()] = description
-
-        return format
-
-    if xheep.are_base_peripherals_configured():
-        base_peripherals = __format_peripherals_to_dicts(base_peripherals)
-    if xheep.are_user_peripherals_configured():
-        user_peripherals = __format_peripherals_to_dicts(user_peripherals)
 
     ext_slave_start_address = string2int(obj["ext_slaves"]["address"])
     ext_slave_size_address = string2int(obj["ext_slaves"]["length"])
@@ -1575,6 +1422,39 @@ def main():
         right_pad_list = None
         bondpad_offsets = None
 
+    """
+    # For simplicity between python config and hjson config, formating peripherals to list of dictionaries instead of list of Peripherals
+    def __format_peripherals_to_dicts(peripherals):
+        format = {}
+
+        for p in peripherals:
+            description = {
+                "offset": f"{p.get_address() & 0xFFFFFFFF:08X}",  # Converts int to its hexadecimal representation on 8 digits
+                "length": f"{p.get_length() & 0xFFFFFFFF:08X}",
+                # Doesn't add path since it's filtered out with hjson config version
+            }
+
+            # Adding DMA specific information
+            if isinstance(p, x_heep_gen.peripherals.base_peripherals.DMA):
+                description["ch_length"] = hex(p.get_ch_length()).split("x")[
+                    1
+                ]  # Converts int to its hexadecimal representation (minimal number of digits)
+                description["num_channels"] = hex(p.get_num_channels()).split("x")[1]
+                description["num_master_ports"] = hex(p.get_num_master_ports()).split(
+                    "x"
+                )[1]
+                description["num_channels_per_master_port"] = hex(
+                    p.get_num_channels_per_master_port()
+                ).split("x")[1]
+
+            # Adding is_included to the description if the peripheral is a UserPeripheral
+            if isinstance(p, x_heep_gen.peripherals.abstractions.UserPeripheral):
+                description["is_included"] = "yes"
+
+            format[p.get_name()] = description
+
+        return format
+
     if xheep.are_base_peripherals_configured():
         # Writes dma parameters into hexadecimal format (removing leading 0x)
         dma_ch_count = hex(dma_ch_count)[2:]
@@ -1589,6 +1469,31 @@ def main():
     base_peripheral_size_address = f"{base_peripheral_size_address & 0xFFFFFFFF:08X}"
     user_peripheral_start_address = f"{user_peripheral_start_address & 0xFFFFFFFF:08X}"
     user_peripheral_size_address = f"{user_peripheral_size_address & 0xFFFFFFFF:08X}"
+    
+    Ctrl + f :
+    ao_peripheral_start_address
+    ao_peripheral_size_address
+    ao_peripherals
+    ao_peripherals_count
+    dma_ch_count
+    dma_ch_size,
+    num_dma_master_ports
+    num_dma_xbar_channels_per_master_port
+    dma_xbar_masters_array
+    peripheral_start_address
+    peripheral_size_address
+    peripherals
+    peripherals_count
+
+    Where : 
+    hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl -> done
+    hw/core-v-mini-mcu/system_bus.sv.tpl
+    sw/device/lib/runtime/core_v_mini_mcu.h.tpl
+    hw/ip/power_manager/data/power_manager.sv.tpl
+    hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl
+    hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
+    hw/ip/power_manager/data/power_manager.hjson.tpl
+    """
 
     kwargs = {
         "xheep": xheep,
@@ -1598,20 +1503,7 @@ def main():
         "external_domains": external_domains,
         "debug_start_address": debug_start_address,
         "debug_size_address": debug_size_address,
-        "ao_peripheral_start_address": base_peripheral_start_address,
-        "ao_peripheral_size_address": base_peripheral_size_address,
-        "ao_peripherals": base_peripherals,
-        "ao_peripherals_count": base_peripherals_count,
-        "dma_ch_count": dma_ch_count,
-        "dma_ch_size": dma_ch_size,
-        "num_dma_master_ports": num_dma_master_ports,
-        "num_dma_xbar_channels_per_master_port": num_dma_xbar_channels_per_master_port,
-        "dma_xbar_masters_array": dma_xbar_array,
         "has_spi_slave": has_spi_slave,
-        "peripheral_start_address": user_peripheral_start_address,
-        "peripheral_size_address": user_peripheral_size_address,
-        "peripherals": user_peripherals,
-        "peripherals_count": user_peripherals_count,
         "ext_slave_start_address": ext_slave_start_address,
         "ext_slave_size_address": ext_slave_size_address,
         "flash_mem_start_address": flash_mem_start_address,

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -1487,12 +1487,12 @@ def main():
 
     Where : 
     hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl -> done
-    hw/core-v-mini-mcu/system_bus.sv.tpl
-    sw/device/lib/runtime/core_v_mini_mcu.h.tpl
-    hw/ip/power_manager/data/power_manager.sv.tpl
-    hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl
-    hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
-    hw/ip/power_manager/data/power_manager.hjson.tpl
+    hw/core-v-mini-mcu/system_bus.sv.tpl -> done
+    sw/device/lib/runtime/core_v_mini_mcu.h.tpl -> done
+    hw/ip/power_manager/data/power_manager.hjson.tpl -> done
+    hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl -> done
+    hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl -> done
+    hw/ip/power_manager/rtl/power_manager.sv.tpl
     """
 
     kwargs = {

--- a/util/x_heep_gen/load_config.py
+++ b/util/x_heep_gen/load_config.py
@@ -2,7 +2,36 @@ import importlib
 from pathlib import PurePath
 from typing import List, Optional, Union
 import hjson
+import os
+import sys
+from jsonref import JsonRef
 
+from .peripherals.base_peripherals import (
+    BasePeripheralDomain,
+    SOC_ctrl,
+    Bootrom,
+    SPI_flash,
+    SPI_memio,
+    DMA,
+    Power_manager,
+    RV_timer_ao,
+    Fast_intr_ctrl,
+    Ext_peripheral,
+    Pad_control,
+    GPIO_ao,
+    UART,
+)
+from .peripherals.user_peripherals import (
+    UserPeripheralDomain,
+    RV_plic,
+    SPI_host,
+    GPIO,
+    I2C,
+    RV_timer,
+    SPI2,
+    PDM2PCM,
+    I2S,
+)
 from .linker_section import LinkerSection
 from .system import BusType, Override, XHeep
 
@@ -177,6 +206,130 @@ def load_linker_config(system: XHeep, config: list):
             end = None
 
         system.add_linker_section(LinkerSection(name, start, end))
+
+
+def load_peripherals_config(system: XHeep, config_path: str):
+    """
+    Reads the whole peripherals configuration.
+
+    :param XHeep system: the system object where the peripherals should be added.
+    :param str config_path: The path to the configuration file.
+    :raise ValueError: If config file does not exist or if peripheral name doesn't match a peripheral class.
+    """
+
+    if not os.path.exists(config_path):
+        raise ValueError(
+            f"Peripherals configuration file {config_path} does not exist."
+        )
+
+    with open(config_path, "r") as file:
+        try:
+            srcfull = file.read()
+            config = hjson.loads(srcfull, use_decimal=True)
+            config = JsonRef.replace_refs(config)
+        except ValueError:
+            raise SystemExit(sys.exc_info()[1])
+
+    for name, fields in config.items():
+        # Base Peripherals
+        if name == "ao_peripherals":
+            base_peripherals = BasePeripheralDomain(
+                int(fields["address"], 16), int(fields["length"], 16)
+            )
+            # iterate over all peripherals and create corresponding objects
+            for peripheral_name, peripheral_config in fields.items():
+                if peripheral_name == "address" or peripheral_name == "length":
+                    continue
+
+                offset = int(peripheral_config["offset"], 16)
+                length = int(peripheral_config["length"], 16)
+                if peripheral_name == "soc_ctrl":
+                    peripheral = SOC_ctrl(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "bootrom":
+                    peripheral = Bootrom(offset, length)
+                elif peripheral_name == "spi_flash":
+                    peripheral = SPI_flash(offset, length)
+                elif peripheral_name == "spi_memio":
+                    peripheral = SPI_memio(offset, length)
+                elif peripheral_name == "dma":
+                    peripheral = DMA(
+                        offset,
+                        length,
+                        int(peripheral_config["ch_length"], 16),
+                        int(peripheral_config["num_channels"], 16),
+                        int(peripheral_config["num_master_ports"], 16),
+                        int(peripheral_config["num_channels_per_master_port"], 16),
+                    )
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "power_manager":
+                    peripheral = Power_manager(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "rv_timer_ao":
+                    peripheral = RV_timer_ao(offset, length)
+                elif peripheral_name == "fast_intr_ctrl":
+                    peripheral = Fast_intr_ctrl(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "ext_peripheral":
+                    peripheral = Ext_peripheral(offset, length)
+                elif peripheral_name == "pad_control":
+                    peripheral = Pad_control(offset, length)
+                elif peripheral_name == "gpio_ao":
+                    peripheral = GPIO_ao(offset, length)
+                elif peripheral_name == "uart":
+                    peripheral = UART(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                else:
+                    raise ValueError(f"Peripheral {peripheral_name} does not exist.")
+                # Adding peripheral to domain
+                base_peripherals.add_peripheral(peripheral)
+
+            # All peripherals in configuration filehave been added
+            system.add_peripheral_domain(base_peripherals)
+        # User Peripherals
+        elif name == "peripherals":
+            user_peripherals = UserPeripheralDomain(
+                int(fields["address"], 16), int(fields["length"], 16)
+            )
+            # iterate over all peripherals and create corresponding objects
+            for peripheral_name, peripheral_config in fields.items():
+                if peripheral_name == "address" or peripheral_name == "length":
+                    continue
+
+                offset = int(peripheral_config["offset"], 16)
+                length = int(peripheral_config["length"], 16)
+                # Skip if the peripheral is not included
+                if peripheral_config["is_included"] == "no":
+                    continue
+                if peripheral_name == "rv_plic":
+                    peripheral = RV_plic(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "spi_host":
+                    peripheral = SPI_host(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "gpio":
+                    peripheral = GPIO(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "i2c":
+                    peripheral = I2C(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "rv_timer":
+                    peripheral = RV_timer(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "spi2":
+                    peripheral = SPI2(offset, length)
+                elif peripheral_name == "pdm2pcm":
+                    peripheral = PDM2PCM(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                elif peripheral_name == "i2s":
+                    peripheral = I2S(offset, length)
+                    peripheral.custom_configuration(peripheral_config["path"])
+                else:
+                    raise ValueError(f"Peripheral {peripheral_name} does not exist.")
+                # Adding peripheral to domain
+                user_peripherals.add_peripheral(peripheral)
+            # All peripherals in configuration file have been added
+            system.add_peripheral_domain(user_peripherals)
 
 
 def load_cfg_hjson(src: str, override: Optional[Override] = None) -> XHeep:

--- a/util/x_heep_gen/peripherals/abstractions.py
+++ b/util/x_heep_gen/peripherals/abstractions.py
@@ -178,6 +178,16 @@ class PeripheralDomain(ABC):
             else [deepcopy(p) for p in self._peripherals]
         )
 
+    def contains_peripheral(self, peripheral_name: str):
+        """
+        Check if the peripheral domain contains a peripheral with the given name.
+
+        :param str peripheral_name: The name of the peripheral to check (case sensitive).
+        :return: True if the peripheral domain contains a peripheral with the given name, False otherwise.
+        :rtype: bool
+        """
+        return any(p.get_name() == peripheral_name for p in self._peripherals)
+
     # Build function
 
     def build(self):

--- a/util/x_heep_gen/peripherals/abstractions.py
+++ b/util/x_heep_gen/peripherals/abstractions.py
@@ -80,7 +80,7 @@ class DataConfiguration(ABC):
 
         :param str config_path: The path to the hjson file that describes the peripheral. If the path does not exist, a FileNotFoundError will be raised.
         """
-        if not path.exists(config_path):
+        if not path.exists(config_path) and not path.exists(config_path + ".tpl"):
             raise FileNotFoundError(f"The config file {config_path} does not exist")
         self._config_path = config_path
 

--- a/util/x_heep_gen/peripherals/user_peripherals.py
+++ b/util/x_heep_gen/peripherals/user_peripherals.py
@@ -100,7 +100,7 @@ class UserPeripheralDomain(PeripheralDomain):
     Length :       0x00100000
     """
 
-    def __init__(self):
+    def __init__(self, base_address: int = 0x30000000, length: int = 0x00100000):
         """
         Initialize the user peripheral domain.
         Base address : 0x30000000
@@ -110,8 +110,8 @@ class UserPeripheralDomain(PeripheralDomain):
         """
         super().__init__(
             name="User",
-            base_address=0x30000000,
-            length=0x00100000,
+            base_address=base_address,
+            length=length,
         )
 
     def add_peripheral(self, peripheral: UserPeripheral):

--- a/util/x_heep_gen/system.py
+++ b/util/x_heep_gen/system.py
@@ -338,12 +338,28 @@ class XHeep:
         """
         return self._base_peripheral_domain.get_peripherals()
 
+    def is_base_peripheral_included(self, peripheral_name: str):
+        """
+        :param str peripheral_name: The name of the peripheral to check (case sensitive).
+        :return: True if the peripheral is included, False otherwise.
+        :rtype: bool
+        """
+        return self._base_peripheral_domain.contains_peripheral(peripheral_name)
+
     def get_user_peripherals(self):
         """
         :return: the user peripherals.
         :rtype: List[UserPeripheral]
         """
         return self._user_peripheral_domain.get_peripherals()
+
+    def is_user_peripheral_included(self, peripheral_name: str):
+        """
+        :param str peripheral_name: The name of the peripheral to check (case sensitive).
+        :return: True if the peripheral is included, False otherwise.
+        :rtype: bool
+        """
+        return self._user_peripheral_domain.contains_peripheral(peripheral_name)
 
     def get_dma(self):
         """


### PR DESCRIPTION
Goal : Remove all peripheral related variables in kwargs, every mako template should call xheep object to get these values

Variables removed : 
    ao_peripheral_start_address
    ao_peripheral_size_address
    ao_peripherals
    ao_peripherals_count
    dma_ch_count
    dma_ch_size,
    num_dma_master_ports
    num_dma_xbar_channels_per_master_port
    dma_xbar_masters_array
    peripheral_start_address
    peripheral_size_address
    peripherals
    peripherals_count

Files changes : 
    hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv.tpl
    hw/core-v-mini-mcu/system_bus.sv.tpl
    sw/device/lib/runtime/core_v_mini_mcu.h.tpl
    hw/ip/power_manager/data/power_manager.hjson.tpl
    hw/core-v-mini-mcu/peripheral_subsystem.sv.tpl
    hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
    hw/ip/power_manager/rtl/power_manager.sv.tpl

Also part of the PR : 
 - Computing dma xbar array in the dma object (computed each time the corresponding get function is called), not in mcu_gen anymore
 - Extending load_config file with a function that takes a file as the "default" configuration (add all missing peripherals in xheep object). Note : when configuration files will be merged, the call in mcu_gen.py to this function should be moved in load_config.py (currently impossible, since load_config.py doesn't know anything about --cfg_peripherals argument)
 - Adding helper function in PeripheralDomain to check if a peripheral is already in the domain or not
 - Removing almost all logic concerning peripherals in mcu_gen.py
 - Doesn't generate not included peripherals in .sv files anymore (especially hw/core-v-mini-mcu/include/core_v_mini_mcu_pkg.sv)

Note : since the docker has a version of python prior to 3.10, match keyword doesn't exist and is replaced with a big if / elif / else block