### PR TITLE
Control of the SPI slave MISO output enable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ test:
 ## Builds the specified app, loads it into the programmer's flash and then opens picocom to see the output
 ## @param PROJECT=<folder_name_of_the_project_to_be_built>
 run-fpga-flash-load:
-	$(MAKE) app LINKER=flash_load TARGET=pynq-z2
+	$(MAKE) app LINKER=flash_load TARGET=pynq-z2 PROJECT=$(PROJECT)
 	$(MAKE) flash-prog || { \
 		echo "\033[0;31mTry holding the RESET button on the FPGA while loading the flash.\033[0m"; \
 		exit 1; \

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv
@@ -169,6 +169,8 @@ module core_v_mini_mcu
     output logic gpio_15_oe_o,
 
     output logic spi_slave_miso_o,
+    input  logic spi_slave_miso_i,
+    output logic spi_slave_miso_oe_o,
     output logic gpio_16_o,
     input  logic gpio_16_i,
     output logic gpio_16_oe_o,
@@ -566,6 +568,7 @@ module core_v_mini_mcu
       .spi_slave_sck_i(spi_slave_sck_i),
       .spi_slave_cs_i(spi_slave_cs_i),
       .spi_slave_miso_o(spi_slave_miso_o),
+      .spi_slave_miso_oe_o(spi_slave_miso_oe_o),
       .spi_slave_mosi_i(spi_slave_mosi_i),
       .debug_core_req_o(debug_req),
       .debug_ndmreset_no(debug_reset_n),

--- a/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
+++ b/hw/core-v-mini-mcu/core_v_mini_mcu.sv.tpl
@@ -312,6 +312,7 @@ ${pad.core_v_mini_mcu_interface}
       .spi_slave_sck_i(spi_slave_sck_i),
       .spi_slave_cs_i(spi_slave_cs_i),
       .spi_slave_miso_o(spi_slave_miso_o),
+      .spi_slave_miso_oe_o(spi_slave_miso_oe_o),
       .spi_slave_mosi_i(spi_slave_mosi_i),
       .debug_core_req_o(debug_req),
       .debug_ndmreset_no(debug_reset_n),

--- a/hw/core-v-mini-mcu/debug_subsystem.sv
+++ b/hw/core-v-mini-mcu/debug_subsystem.sv
@@ -160,6 +160,8 @@ module debug_subsystem
     assign dm_resp             = dbg_spi_resp[0];
     assign spi_slave_resp      = dbg_spi_resp[1];
 
+    // To prevent the spi slave from keeping the MISO signal high
+    // when it is not its turn to speak
     assign spi_slave_miso_oe_o = ~spi_slave_cs_i;
 
     // 2-to-1 crossbar

--- a/hw/core-v-mini-mcu/debug_subsystem.sv
+++ b/hw/core-v-mini-mcu/debug_subsystem.sv
@@ -23,6 +23,7 @@ module debug_subsystem
     input  logic spi_slave_sck_i,
     input  logic spi_slave_cs_i,
     output logic spi_slave_miso_o,
+    output logic spi_slave_miso_oe_o,
     input  logic spi_slave_mosi_i,
 
     output logic debug_ndmreset_no,
@@ -154,10 +155,12 @@ module debug_subsystem
         .obi_master_r_data_i(spi_slave_resp.rdata)
     );
 
-    assign dbg_spi_req[0] = dm_req;
-    assign dbg_spi_req[1] = spi_slave_req;
-    assign dm_resp        = dbg_spi_resp[0];
-    assign spi_slave_resp = dbg_spi_resp[1];
+    assign dbg_spi_req[0]      = dm_req;
+    assign dbg_spi_req[1]      = spi_slave_req;
+    assign dm_resp             = dbg_spi_resp[0];
+    assign spi_slave_resp      = dbg_spi_resp[1];
+
+    assign spi_slave_miso_oe_o = ~spi_slave_cs_i;
 
     // 2-to-1 crossbar
     xbar_varlat_n_to_one #(

--- a/pad_cfg.hjson
+++ b/pad_cfg.hjson
@@ -120,7 +120,7 @@
             type: inout
             mux: {
                 spi_slave_miso: {
-                    type: output
+                    type: inout
                 }
                 gpio_16: {
                     type: inout

--- a/sw/applications/demo_spi_master_slave/main.c
+++ b/sw/applications/demo_spi_master_slave/main.c
@@ -42,7 +42,7 @@
  4.e) You can restart the demo by resetting the master. 
  4.f) You can invert the roles by resetting both and releasing first the former slave.
 ____________________________________________________
-         [  ][  ][  ](Sy)(Ck)[  ][  ][  ][  ][  ]   |
+         [GD][  ][  ](Sy)(Ck)[  ][  ][  ][  ][Vd]   |
          [  ][  ][  ][  ][  ][  ](Cs)[  ][  ][  ]   | 
                                                     |
  [  ][  ][  ][  ](Mo)(Mi)[  ][  ]                   |
@@ -51,6 +51,7 @@ ____________________________________________________
                     Master->|(Ck)(Mo)           |   
                             |(Cs)[  ]           | PMODs
 
+To self-test you can connect the Sy to Vd (3V3)
 
 Disclaimer: 
 The FPGAs can have different bitstreams as long as the pinout remains the same. 

--- a/sw/applications/demo_spi_master_slave/main.c
+++ b/sw/applications/demo_spi_master_slave/main.c
@@ -178,7 +178,7 @@ int main(){
         #endif
 
         // Initilize the SPI host IP
-        if( spi_host_init(spi_host1)!= SPI_FLAG_SUCCESS) return EXIT_FAILURE;
+        if( spi_host_init(spi_host1, 0)!= SPI_FLAG_SUCCESS) return EXIT_FAILURE;
 
         // We will request chunks of chunk_w words. 
         // We will repeat the process N times until we have read the entirety of the buffer. 

--- a/sw/applications/example_spi_slave/main.c
+++ b/sw/applications/example_spi_slave/main.c
@@ -72,7 +72,7 @@ int main(){
     uint16_t i;
 
     // Initialize the SPI host. 
-    if( spi_host_init(spi_host1)!= SPI_FLAG_SUCCESS) return EXIT_FAILURE;
+    if( spi_host_init(spi_host1, 0)!= SPI_FLAG_SUCCESS) return EXIT_FAILURE;
 
     // Use the SPI Host SDK to write into the SPI slave.
     // In the SPI Slave SDK there are the needed SPI HOST functions to control the SPI Slave. 

--- a/sw/applications/example_spi_slave/main.c
+++ b/sw/applications/example_spi_slave/main.c
@@ -5,6 +5,21 @@
 #include "spi_host.h"
 #include "spi_slave_sdk.h"
 
+
+/*
+Connections to test on the pynq-z2 FPGA
+____________________________________________________
+         [GD][  ][  ](Sy)(Ck)[  ][  ][  ][  ][Vd]   |
+         [  ][  ][  ][  ][  ][  ](Cs)[  ][  ][  ]   | 
+                                                    |
+ [  ][  ][  ][  ](Mo)(Mi)[  ][  ]                   |
+                                                    |
+                            |(Mi)[  ]           ____|
+                    Master->|(Ck)(Mo)           |   
+                            |(Cs)[  ]           | PMODs
+*/
+
+
 /* By default, printfs are activated for FPGA and disabled for simulation. */
 #define PRINTF_IN_FPGA 1
 #define PRINTF_IN_SIM 0

--- a/sw/device/lib/sdk/spi_slave/spi_slave_sdk.c
+++ b/sw/device/lib/sdk/spi_slave/spi_slave_sdk.c
@@ -15,7 +15,7 @@
 /*
 * Initilize the SPI Host
 */
-spi_flags_e spi_host_init(spi_host_t* host) {
+spi_flags_e spi_host_init(spi_host_t* host, uint8_t csid) {
  
     // Enable spi host device
     if( spi_set_enable(host, true) != SPI_FLAG_SUCCESS) return SPI_HOST_FLAG_NOT_INIT;
@@ -32,9 +32,9 @@ spi_flags_e spi_host_init(spi_host_t* host) {
         .cpha       = 0,
         .cpol       = 0            
     });
-    spi_set_configopts(host, 0, chip_cfg);;
+    spi_set_configopts(host, csid, chip_cfg);
 
-    if(spi_set_csid(host, 0) != SPI_FLAG_SUCCESS) return SPI_HOST_FLAG_CSID_INVALID;
+    if(spi_set_csid(host, csid) != SPI_FLAG_SUCCESS) return SPI_HOST_FLAG_CSID_INVALID;
 
     return SPI_FLAG_SUCCESS; // Success
 }

--- a/sw/device/lib/sdk/spi_slave/spi_slave_sdk.h
+++ b/sw/device/lib/sdk/spi_slave/spi_slave_sdk.h
@@ -41,7 +41,7 @@ typedef enum {
     SPI_SLAVE_FLAG_SIZE_OF_DATA_EXCEEDED    = 0x0004, 
 } spi_flags_e;
 
-spi_flags_e spi_host_init(spi_host_t* host);
+spi_flags_e spi_host_init(spi_host_t* host, uint8_t csid);
 spi_flags_e spi_slave_write(spi_host_t* host, uint8_t* write_addr, uint8_t* read_ptr, uint16_t length_B);
 uint16_t spi_slave_request_read( spi_host_t* host, uint8_t* read_address, uint16_t length_B, uint8_t dummy_cycles );
 void spi_slave_send_dummy_cycles( spi_host_t* host, uint8_t dummy_cycles );


### PR DESCRIPTION
In the spi slave, the output enable was set by default as output. 
This is ok if you only have one master and one slave, but if you want to connect more than one (e.g. HEEPidermis) the slave would be forcing the MISO signal to remain high as long as it is not its turn to speak, making it impossible for other slaves to speak. 

The solution for this is to set it as inout and controlling the output enable with the chip select connected to the spi slave (which is active low). This way the pad is left in high-impedance while it's not the turn of the spi slave. 

I tested this change on verilator and FPGA and it works fine :) 