### PR TITLE
Change DMA HAL check  

### DIFF
--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -762,8 +762,6 @@ dma_config_flags_t dma_validate_transaction(    dma_trans_t        *p_trans,
          * transactions
           */
         if( p_trans->win_du > p_trans->size_d1_du && p_trans->mode != DMA_TRANS_MODE_CIRCULAR )
-
-        if( p_trans->win_du > p_trans->size_d1_du )
         {
             p_trans->flags |= DMA_CONFIG_WINDOW_SIZE;
             p_trans->flags |= DMA_CONFIG_CRITICAL_ERROR;

--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -757,7 +757,12 @@ dma_config_flags_t dma_validate_transaction(    dma_trans_t        *p_trans,
          * The window size cannot be larger than the transaction size. Although
          * this would not cause any error, the transaction is rejected because
          * it is likely a mistake.
-         */
+         * UNLESS the transaction is using the circular mode, in which case this
+         * check does not make sense as the window count is carried over different
+         * transactions
+          */
+        if( p_trans->win_du > p_trans->size_d1_du && p_trans->mode != DMA_TRANS_MODE_CIRCULAR )
+
         if( p_trans->win_du > p_trans->size_d1_du )
         {
             p_trans->flags |= DMA_CONFIG_WINDOW_SIZE;


### PR DESCRIPTION
There was this check that is no longer valid for the circular mode, as the windows do not reset, they can be larger than the transaction (does happen in HEEPidermis). Tested on HEEPidermis

@TommiTerza @davidmallasen 