### PR TITLE
Fix signature for user-define IRQ in GPIO driver

### DIFF
--- a/sw/device/lib/drivers/gpio/gpio.c
+++ b/sw/device/lib/drivers/gpio/gpio.c
@@ -148,7 +148,7 @@ __attribute__((always_inline)) void select_gpio_domain(gpio_pin_number_t pin)
 /****************************************************************************/
 
 gpio_result_t gpio_assign_irq_handler( uint32_t intr_id,
-                                       void *handler() )
+                                       void (*handler)() )
 {
   if( intr_id >= GPIO_INTR_START && intr_id <= GPIO_INTR_END )
   {

--- a/sw/device/lib/drivers/gpio/gpio.h
+++ b/sw/device/lib/drivers/gpio/gpio.h
@@ -138,7 +138,7 @@ typedef struct gpio_cfg
  * @return The result of the operation
  */
 gpio_result_t gpio_assign_irq_handler( uint32_t intr_id,
-                                       void *handler() );
+                                       void (*handler)() );
 
 /**
  * @brief Resets all handlers to the dummy handler.


### PR DESCRIPTION
## Description
The current `gpio_assign_irq_handler()` function in `gpio.c` accepts, as its second argument, a pointer to a function of type `(void *)`. This is considered an issue in recent compilers (tested with `corev-openhw-gcc-ubuntu2204-20240530`, version 14.1.0). This PR changes the signature to match the expected behaviour, i.e., accepting a pointer to a function of type `void`.