### PR TITLE
Fix CMakeLists regex to match "main"

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -145,7 +145,7 @@ FOREACH(file_path IN LISTS new_list)
     endif()
   elseif( (${file_path} MATCHES "${SOURCE_PATH}external/") AND ( NOT  ${file_path} MATCHES "exclude" ) )
     SET(add 1)
-  elseif( ${file_path} MATCHES "${SOURCE_PATH}applications/${PROJECT}/.*${MAINFILE}\." ) # look for main.*
+  elseif( ${file_path} MATCHES "${SOURCE_PATH}applications/${PROJECT}/${MAINFILE}\\." ) # look for main.*
     SET(app_found 1)
   elseif( ${file_path} MATCHES "${SOURCE_PATH}applications/${PROJECT}/" ) # other sources
     SET(add 1)
@@ -182,7 +182,7 @@ if( app_found EQUAL 0 )
       if(NOT ${file_path} MATCHES ".*/crt/.*")
         SET(add 1)
       endif()
-    elseif( ( ${file_path} MATCHES "${ROOT_PROJECT}applications/${PROJECT}/" ) AND ( NOT ${file_path} MATCHES "${ROOT_PROJECT}applications/${PROJECT}/.*${MAINFILE}\." ) AND ( NOT  ${file_path} MATCHES "exclude" ) )
+    elseif( ( ${file_path} MATCHES "${ROOT_PROJECT}applications/${PROJECT}/" ) AND ( NOT ${file_path} MATCHES "${ROOT_PROJECT}applications/${PROJECT}/${MAINFILE}\\." ) AND ( NOT  ${file_path} MATCHES "exclude" ) )
       SET(add 1)
     endif()
 


### PR DESCRIPTION
The MATCHES regex that matches and skips source files named "main" is incorrect and actually matches any file containing "main", such as "remain.c" or "maintain.c".

There were two issues in the MATCHES pattern:
1. The `.*` in `/.*${MAINFILE}` (which I guess was added to include both `/main` and `/.*/main`) will also match any string at the beginning of the file name, e.g. `/remain`.
2. The `\` in `"...${MAINFILE}\."` needs to be escaped as `\\` because of the double quotes (`"\\."` becomes `\.` which is the regex for a literal `.`, but `"\."` becomes just `.` which is the regex for "match any character"), so `"${MAINFILE}\."` will match the `main.` in `main.c` but also the `maint` in `maintain.c`.