### PR TITLE
yosys_spiflash vcs compilation error fixed

### DIFF
--- a/tb/yosys_spiflash.sv
+++ b/tb/yosys_spiflash.sv
@@ -283,7 +283,7 @@ module spiflash (
     end
   endtask
 
-  always_ff @(posedge csb or negedge csb) begin
+  always @(posedge csb or negedge csb) begin
     if (csb) begin
       if (verbose) begin
         $display("");
@@ -310,7 +310,7 @@ module spiflash (
     end
   end
 
-  always_ff @(posedge csb or negedge csb or posedge clk or negedge clk) begin
+  always @(posedge csb or negedge csb or posedge clk or negedge clk) begin
     spi_io_vld = 0;
     if (!csb && !clk) begin
       if (dummycount > 0) begin
@@ -393,7 +393,7 @@ module spiflash (
     end
   end
 
-  always_ff @(posedge clk) begin
+  always @(posedge clk) begin
     if (!csb) begin
       if (dummycount > 0) begin
         dummycount = dummycount - 1;


### PR DESCRIPTION
@StMiky yosys_spiflash has been fixed for vcs compilation.

Problem:  Illegal combination of procedural drivers
buffer declared at line 60 is driven by two different always_ff procedural blocks. In SystemVerilog, any variable assigned in an always_ff may only be assigned in that single always_ff block. VCS enforces this strictly.

Solution: change always_ff @ to always @, this should fix the problem.

test conducted:
vcs
    - load from SPI flash; passed
    - execute from flash; passed
verilator
    -load from SPI flash; passed