### PR TITLE
Fix assembler flags

### DIFF
--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -385,7 +385,7 @@ if (${COMPILER} MATCHES "clang")
                              -Wno-unused-command-line-argument")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CLANG_EXTRA_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_EXTRA_FLAGS}")
-  set(CMAKE_ASM_FLAGS ${BASE_COMPILER_FLAGS})
+  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${CLANG_EXTRA_FLAGS}")
 endif()
 
 # In case of wanting to create a library with those subdirectories


### PR DESCRIPTION
## Description
Add missing assembler flags in `CMakeLists.txt`. Assembler flags had the default value from `riscv.cmake`, while only C and C++ compile flags were correctly updated.