### PR TITLE
Fix build error in UPF-enabled QuestaSim simulation

### DIFF
--- a/hw/simulation/sram_wrapper.sv
+++ b/hw/simulation/sram_wrapper.sv
@@ -29,7 +29,9 @@ module sram_wrapper #(
     // output ports
     output logic [31:0] rdata_o
 );
+`ifndef USE_UPF
   assign pwrgate_ack_no = pwrgate_ni;
+`endif
   tc_sram #(
       .NumWords (NumWords),
       .DataWidth(DataWidth),


### PR DESCRIPTION
Current simulation using UPF under QuestaSim reports vopt-9032 errors due to power switch ack ports being already driven by HDL code.