### PR TITLE
Speed up UART in simulation

### DIFF
--- a/sw/device/target/aup-zu3/x-heep.h
+++ b/sw/device/target/aup-zu3/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_AUP_ZU3 1
 #define TARGET_IS_FPGA 1
 

--- a/sw/device/target/genesys2/x-heep.h
+++ b/sw/device/target/genesys2/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_GENESYS2 1
 #define TARGET_IS_FPGA 1
 

--- a/sw/device/target/nexys-a7-100t/x-heep.h
+++ b/sw/device/target/nexys-a7-100t/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_NEXYS_A7_100T 1
 #define TARGET_IS_FPGA 1
 

--- a/sw/device/target/pynq-z2/x-heep.h
+++ b/sw/device/target/pynq-z2/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_PYNQ_Z2 1
 #define TARGET_IS_FPGA 1
 

--- a/sw/device/target/sim/x-heep.h
+++ b/sw/device/target/sim/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 100*1000*1000
-#define UART_BAUDRATE 256000
+#define REFERENCE_CLOCK_Hz (100*1000*1000) // 100 MHz for simulation
+#define UART_BAUDRATE (REFERENCE_CLOCK_Hz / 20) // close to maximum baud rate (/16)
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_SIM 1
 
 /**

--- a/sw/device/target/systemc/x-heep.h
+++ b/sw/device/target/systemc/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 100*1000*1000
-#define UART_BAUDRATE 256000
+#define REFERENCE_CLOCK_Hz (100*1000*1000) // 100 MHz for simulation
+#define UART_BAUDRATE (REFERENCE_CLOCK_Hz / 20) // close to maximum baud rate (/16)
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_SYSTEMC 1
 
 /**

--- a/sw/device/target/zcu102/x-heep.h
+++ b/sw/device/target/zcu102/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_ZCU102 1
 #define TARGET_IS_FPGA 1
 

--- a/sw/device/target/zcu104/x-heep.h
+++ b/sw/device/target/zcu104/x-heep.h
@@ -12,15 +12,11 @@ extern "C" {
 #endif  // __cplusplus
 
 
-#define REFERENCE_CLOCK_Hz 15*1000*1000
+#define REFERENCE_CLOCK_Hz (15*1000*1000) // 15 MHz for FPGA synthesis
 #define UART_BAUDRATE 9600
 // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
-// NCO creates 16x of baudrate. So, in addition to the nco_width,
-// 2^4 should be multiplied.
-// We assume that the lowest baudrate will be 9600, and the largest 256000. 
-// Given this range, by dividing by 100 it always remains integer and below 32-bits.
-// This saves us the need of performing 64-bit divisions to compute NCO. 
-#define UART_NCO ((uint32_t)(((uint32_t)((uint32_t)(UART_BAUDRATE/100))<<20)/((uint32_t)(REFERENCE_CLOCK_Hz/100))))
+// Note that this will be calculated at compile time, so no 64-bit operations will be performed in CPU.
+#define UART_NCO ((uint32_t)( (((uint64_t)UART_BAUDRATE * 16) << 16) / REFERENCE_CLOCK_Hz ))
 #define TARGET_ZCU104 1
 #define TARGET_IS_FPGA 1
 

--- a/tb/testharness.sv
+++ b/tb/testharness.sv
@@ -403,7 +403,7 @@ module testharness #(
   end
 
   uartdpi #(
-      .BAUD('d256000),
+      .BAUD(CLK_FREQUENCY * 1000 / 20),  // close to maximum baud rate (/16)
       .FREQ(CLK_FREQUENCY * 1000),  //Hz
       .NAME("uart0")
   ) i_uart0 (


### PR DESCRIPTION
Simulation UART was set to a speed of 256000 baud, when theoretically it can reach up to almost CLK_FREQ/16. This causes UART to be a bottleneck in apps that print a lot of info, making the simulation take very long to finish.

This commit changes the baud rate to CLK_FREQ/20 (close to the limit), i.e. each UART bit lasts exactly 20 clock cycles.
(In other words, baud rate is now 5,000,000.)
The UART_NCO macro has been rewritten to accommodate this new value without overflowing.

Text-heavy applications have been accelerated about a tenfold.

Note that this does not touch the UART speed in FPGA implementation, which still defaults to 9600 baud (could be accelerated to 115200 but this probably won't be an issue).