### PR TITLE
Add libelf-dev dependency to doc

### DIFF
--- a/configs/general.py
+++ b/configs/general.py
@@ -18,7 +18,7 @@ from x_heep_gen.peripherals.base_peripherals import (
 )
 
 from x_heep_gen.peripherals.base_peripherals_domain import BasePeripheralDomain
-from x_heep_gen.peripherals.user_peripherals_domain import UserPeripheralDomain,
+from x_heep_gen.peripherals.user_peripherals_domain import UserPeripheralDomain
 
 from x_heep_gen.peripherals.user_peripherals import (
     RV_plic,

--- a/docs/source/GettingStarted/Setup.md
+++ b/docs/source/GettingStarted/Setup.md
@@ -44,7 +44,7 @@ To use `X-HEEP`, first you will need to install some OS dependencies.
 
 The following command `apt` command should install every required package (tested on an Ubuntu 22.04 distribution):
 ```bash
-sudo apt install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev help2man perl make g++ libfl2 libfl-dev zlibc zlib1g zlib1g-dev ccache mold libgoogle-perftools-dev numactl
+sudo apt install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev help2man perl make g++ libfl2 libfl-dev zlibc zlib1g zlib1g-dev ccache mold libgoogle-perftools-dev numactl libelf-dev
 ```
 
 Errors occurring when installing the following packages may be ignored:


### PR DESCRIPTION
Update documentation: 

- Add new dependency. I needed `libelf-dev` to build the Verilator 5.040 simulation in Ubuntu 22.04 and 24.04. Fixes:
```
ERROR: Vtestharness.mk:92: warning: overriding recipe for target 'tb_top.o'
Vtestharness.mk:90: warning: ignoring old recipe for target 'tb_top.o'
mold: fatal: library not found: elf
collect2: error: ld returned 1 exit status
make[2]: *** [Vtestharness.mk:96: Vtestharness] Error 1
make[1]: *** [Makefile:13: Vtestharness] Error 2
```

Minor change:

- Remove comma in the general python-based MCU generation example

