### PR TITLE
Update profile to search FST files directly. Fix profile CV32E20 path in hierarchy

### DIFF
--- a/util/profile/configs/cv32e20.wal
+++ b/util/profile/configs/cv32e20.wal
@@ -1,11 +1,11 @@
 ; cv32e20
-(alias clk TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.if_stage_i.clk_i)
-(alias rst_ni TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.if_stage_i.rst_ni)
+(alias clk TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.if_stage_i.clk_i)
+(alias rst_ni TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.if_stage_i.rst_ni)
 
-(alias pc TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.if_stage_i.pc_id_o)
-(alias instr TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.if_stage_i.instr_rdata_id_o)
-(alias instr_valid TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.if_stage_i.instr_valid_id_o)
+(alias pc TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.if_stage_i.pc_id_o)
+(alias instr TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.if_stage_i.instr_rdata_id_o)
+(alias instr_valid TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.if_stage_i.instr_valid_id_o)
 
-(alias mcycle TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_core.cs_registers_i.mhpmcounter<0>)
+(alias mcycle TOP.testharness.x_heep_system_i.core_v_mini_mcu_i.cpu_subsystem_i.gen_cv32e20.cv32e20_i.u_cve2_top.u_cve2_core.cs_registers_i.mhpmcounter<0>)
 
 (defmacro fire [] `(&& clk rst_ni instr_valid))

--- a/util/profile/run_profile.sh.tpl
+++ b/util/profile/run_profile.sh.tpl
@@ -15,12 +15,7 @@ fi
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
 # Get the waveform file
-WAVE_FILE=$(find $ROOT_DIR/build -name "*.vcd")
-
-# Copy WAVE_FILE in a new file with .fst extension
-cp $WAVE_FILE $WAVE_FILE.fst
-
-WAVE_FILE=$WAVE_FILE.fst
+WAVE_FILE=$(find $ROOT_DIR/build -name "*.fst")
 
 # Profile report directory
 PROFILE_REPORT_DIR=$ROOT_DIR/util/profile


### PR DESCRIPTION
Update the profile tool:

- The new version of Verilator does not generate VCD files. Updating bash script to only search for FST files. The script could search for both file extensions to maintain the compatibility with the old Verilator version. Is it needed?
- Fix CV32E20 path in the profile's configuration file