### PR TITLE
Remove conditional for pull request event in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
     needs: determine-image-tag
     container:
       image: ghcr.io/esl-epfl/x-heep/x-heep-toolchain:${{ needs.determine-image-tag.outputs.tag }}
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Now if you look at the main branch it always says this job was skipped because it doesn't run on push to main. This PR fixes this.