### PR TITLE
Add CV32E40P python config for MCU gen

### DIFF
--- a/docs/source/How_to/Simulate.md
+++ b/docs/source/How_to/Simulate.md
@@ -2,8 +2,6 @@
 
 This project supports simulation with Verilator, Synopsys VCS, Siemens Questasim and Cadence Xcelium.
 We use [FuseSoC](https://github.com/olofk/fusesoc) for all the EDA tools we use. The `fusesoc` commands are used in the targets in the Makefile.
-For example, if you want to set the `FPU` and `COREV_PULP` parameters of the `cv32e40p` CPU,
-you need to add next to your compilation command `FUSESOC_PARAM="--COREV_PULP=1 --FPU=1"`
 Below the different EDA examples commands.
 
 ## Simulating with Verilator

--- a/hw/core-v-mini-mcu/cpu_subsystem.sv
+++ b/hw/core-v-mini-mcu/cpu_subsystem.sv
@@ -324,7 +324,9 @@ module cpu_subsystem
   end else begin : gen_cv32e40p
 
     // instantiate the core
-    cv32e40p_top #() cv32e40p_top_i (
+    cv32e40p_top #(
+        .COREV_CLUSTER(0)
+    ) cv32e40p_top_i (
         .clk_i (clk_i),
         .rst_ni(rst_ni),
 

--- a/hw/core-v-mini-mcu/cpu_subsystem.sv.tpl
+++ b/hw/core-v-mini-mcu/cpu_subsystem.sv.tpl
@@ -348,12 +348,10 @@ module cpu_subsystem
 % if cpu.is_defined("corev_pulp"):
         .COREV_PULP(${cpu.get_sv_str("corev_pulp")}),
 % endif
-% if cpu.is_defined("corev_cluster"): # Disabled. Use ${cpu.get_sv_str("corev_cluster")} if needed
-        .COREV_CLUSTER(0),
-% endif
 % if cpu.is_defined("num_mhpmcounters"):
-        .NUM_MHPMCOUNTERS(${cpu.get_sv_str("num_mhpmcounters")})
+        .NUM_MHPMCOUNTERS(${cpu.get_sv_str("num_mhpmcounters")}),
 % endif
+        .COREV_CLUSTER(0)
     ) cv32e40p_top_i (
         .clk_i (clk_i),
         .rst_ni(rst_ni),

--- a/util/x_heep_gen/cpu/cv32e40p.py
+++ b/util/x_heep_gen/cpu/cv32e40p.py
@@ -13,7 +13,6 @@ class cv32e40p(CPU):
         fpu_others_lat=None,
         zfinx=None,
         corev_pulp=None,
-        corev_cluster=None,
         num_mhpmcounters=None,
     ):
         super().__init__("cv32e40p")
@@ -28,9 +27,6 @@ class cv32e40p(CPU):
                 raise ValueError(f"FPU must be 0, 1, True, or False, got '{fpu}'")
 
             self.params["fpu"] = bool(fpu)
-
-        else:
-            self.params["fpu"] = False
 
         if fpu_addmul_lat is not None:
             if fpu is None or fpu in (0, False):
@@ -50,9 +46,6 @@ class cv32e40p(CPU):
 
             self.params["fpu_addmul_lat"] = fpu_addmul_lat
 
-        else:
-            self.params["fpu_addmul_lat"] = 0
-
         if fpu_others_lat is not None:
             if fpu is None or fpu in (0, False):
                 raise ValueError("FPU_OTHERS_LAT requires FPU enabled")
@@ -71,9 +64,6 @@ class cv32e40p(CPU):
 
             self.params["fpu_others_lat"] = fpu_others_lat
 
-        else:
-            self.params["fpu_others_lat"] = 0
-
         if zfinx is not None:
             if fpu is None or fpu in (0, False):
                 raise ValueError("ZFINX requires FPU enabled")
@@ -89,9 +79,6 @@ class cv32e40p(CPU):
 
             self.params["zfinx"] = bool(zfinx)
 
-        else:
-            self.params["zfinx"] = False
-
         if corev_pulp is not None:
             if isinstance(corev_pulp, str):
                 if corev_pulp.lower() not in ("true", "false", "1", "0"):
@@ -106,27 +93,6 @@ class cv32e40p(CPU):
                 )
 
             self.params["corev_pulp"] = bool(corev_pulp)
-
-        else:
-            self.params["corev_pulp"] = False
-
-        if corev_cluster is not None:
-            if isinstance(corev_cluster, str):
-                if corev_cluster.lower() not in ("true", "false", "1", "0"):
-                    raise ValueError(
-                        f"COREV_CLUSTER must be 0, 1, True, or False, got '{corev_cluster}'"
-                    )
-                corev_cluster = corev_cluster.lower() in ("true", "1")
-
-            if corev_cluster not in (0, 1, True, False):
-                raise ValueError(
-                    f"COREV_CLUSTER must be 0, 1, True, or False, got '{corev_cluster}'"
-                )
-
-            self.params["corev_cluster"] = bool(corev_cluster)
-
-        else:
-            self.params["corev_cluster"] = False
 
         if num_mhpmcounters is not None:
             if isinstance(num_mhpmcounters, str):
@@ -144,9 +110,6 @@ class cv32e40p(CPU):
 
             self.params["num_mhpmcounters"] = num_mhpmcounters
 
-        else:
-            self.params["num_mhpmcounters"] = 1
-
     def get_sv_str(self, param_name: str) -> str:
         """
         Get the string representation of the param_name parameter to be used in the SystemVerilog templates.
@@ -162,8 +125,6 @@ class cv32e40p(CPU):
         elif param_name == "zfinx":
             return "1" if value else "0"
         elif param_name == "corev_pulp":
-            return "1" if value else "0"
-        elif param_name == "corev_cluster":
             return "1" if value else "0"
         else:
             return str(value)


### PR DESCRIPTION
Add the following CV32E40P core parameters to the python-based MCU generator:

- rv32f
- rv32f_addmul_lat
- rv32f_compconv_lat
- rv32zfinx
- rv32xcv
- rv32xcvelw (disabled)
- num_mhpmcounters

The parameters of `x_heep_system.sv`, `core_v_mini_mcu.sv`, and `cpu_subsystem.sv` that changed the CV32E40P core instantiation become unused.