### PR TITLE
Update docs and parameters for new compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ XHEEP_CONFIG_CACHE ?= $(BUILD_DIR)/xheep_config_cache.pickle
 
 # Compiler options are 'gcc' (default) and 'clang'
 COMPILER 		?= gcc
-# Compiler prefix options are 'riscv32-unknown-' (default) and 'riscv32-corev-'
+# Compiler prefix options are 'riscv32-corev-' (default) and 'riscv32-unknown-'
 COMPILER_PREFIX ?= riscv32-corev-
 # Compiler flags to be passed (for both linking and compiling)
 COMPILER_FLAGS 	?=
@@ -186,7 +186,7 @@ format-python:
 ## @param TARGET=sim(default),systemc,pynq-z2,nexys-a7-100t,zcu104,zcu102
 ## @param LINKER=on_chip(default),flash_load,flash_exec
 ## @param COMPILER=gcc(default),clang
-## @param COMPILER_PREFIX=riscv32-unknown-(default)
+## @param COMPILER_PREFIX=riscv32-corev-(default),riscv32-unknown-
 ## @param ARCH=rv32imc(default),<any_RISC-V_ISA_string_supported_by_the_CPU>
 app: clean-app
 	@$(MAKE) -C sw PROJECT=$(PROJECT) TARGET=$(TARGET) LINKER=$(LINKER) LINK_FOLDER=$(LINK_FOLDER) COMPILER=$(COMPILER) COMPILER_PREFIX=$(COMPILER_PREFIX) COMPILER_FLAGS=$(COMPILER_FLAGS) ARCH=$(ARCH) SOURCE=$(SOURCE) \
@@ -195,7 +195,8 @@ app: clean-app
 	echo "\033[0;31mIf you do not understand why, it is likely that you either:\033[0m"; \
 	echo "\033[0;31m  a) offended the Leprechaun of Electronics\033[0m"; \
 	echo "\033[0;31m  b) forgot to run make mcu-gen\033[0m"; \
-	echo "\033[0;31mI would start by checking b) if I were you!\033[0m"; \
+	echo "\033[0;31m  c) forgot to set the correct compiler parameters (check the docs!)\033[0m"; \
+	echo "\033[0;31mI would start by checking b) or c) if I were you!\033[0m"; \
 	exit 1; \
 	}
 	@python scripts/building/mem_usage.py

--- a/docs/source/How_to/CompileApps.md
+++ b/docs/source/How_to/CompileApps.md
@@ -19,14 +19,14 @@ Don't forget to set the `RISCV_XHEEP` env variable to the compiler folder (witho
 
 You can select the application to run, the target, compiler, etc. by modifying the parameters. The compiler flags explicitely specified by the user will override those already existing (e.g. the default optimization level is `-O2`, passing `COMPILER_FLAGS=-Os` will override the `-O2`). This can be used to pass preprocessor definitions (e.g. pasing `make app COMPILER_FLAGS=-DENABLE_PRINTF` is equivalent to adding `#define ENABLE_PRINTF` on all included files). 
 ```
-app PROJECT=<folder_name_of_the_project_to_be_built> TARGET=sim(default),systemc,pynq-z2,nexys-a7-100t,zcu104,zcu102 LINKER=on_chip(default),flash_load,flash_exec COMPILER=gcc(default),clang COMPILER_PREFIX=riscv32-unknown-(default) ARCH=rv32imc_zicsr(default),<any_RISC-V_ISA_string_supported_by_the_CPU> 
+app PROJECT=<folder_name_of_the_project_to_be_built> TARGET=sim(default),systemc,pynq-z2,nexys-a7-100t,zcu104,zcu102 LINKER=on_chip(default),flash_load,flash_exec COMPILER=gcc(default),clang COMPILER_PREFIX=riscv32-corev-(default),riscv32-unknown- ARCH=rv32imc_zicsr(default),<any_RISC-V_ISA_string_supported_by_the_CPU> 
 
 Params:
     - PROJECT (ex: <folder_name_of_the_project_to_be_built>) 
     - TARGET (ex: sim(default),systemc,pynq-z2,nexys-a7-100t,zcu104,zcu102) 
     - LINKER (ex: on_chip(default),flash_load,flash_exec) 
     - COMPILER (ex: gcc(default),clang) 
-    - COMPILER_PREFIX (ex: riscv32-unknown-(default)) 
+    - COMPILER_PREFIX (ex: riscv32-corev-(default),riscv32-unknown-) 
     - COMPILER_FLAGS (ex: -O0, "-Wall -l<library>")
     - ARCH (ex: rv32imc_zicsr(default),<any_RISC-V_ISA_string_supported_by_the_CPU>)
 ```
@@ -35,18 +35,28 @@ Params:
 You can run `make help` or `make` to see the most up-to-date documentation for the makefile. This includes the parameters available for this command, as well as the documentation for all other commands.
 ```
 
-For instance, to compile the `hello world` app with Clang for the pynq-z2 FPGA, just run:
+For instance, to compile the `hello world` app with the default compiler for the pynq-z2 FPGA, just run:
 
 ```
-make app PROJECT=hello_world TARGET=pynq-z2 COMPILER=clang
+make app PROJECT=hello_world TARGET=pynq-z2
 ```
 
-## Using the OpenHW Group compiler
+## Using the standard GCC or Clang compilers
+
+If you want to use the standard GCC or Clang toolchains, make sure to point the `RISCV_XHEEP` env variable to the corresponding compiler, then just run:
+
+```bash
+make app COMPILER=gcc COMPILER_PREFIX=riscv32-unknown- ARCH=rv32imc_zicsr
+
+make app COMPILER=clang COMPILER_PREFIX=riscv32-unknown- ARCH=rv32imc_zicsr
+```
+
+## Using the OpenHW Group compiler with PULP extensions
 
 If you want to use the OpenHW Group [GCC](https://www.embecosm.com/resources/tool-chain-downloads/#corev) compiler with CORE_PULP extensions, make sure to point the `RISCV_XHEEP` env variable to the OpenHW Group compiler, then just run:
 
 ```
-make app COMPILER_PREFIX=riscv32-corev- ARCH=rv32imc_zicsr_zifencei_xcvhwlp_xcvmem_xcvmac_xcvbi_xcvalu_xcvsimd_xcvbitmanip
+make app COMPILER=gcc COMPILER_PREFIX=riscv32-corev- ARCH=rv32imc_zicsr_zifencei_xcvhwlp_xcvmem_xcvmac_xcvbi_xcvalu_xcvsimd_xcvbitmanip
 ```
 
 ## Using the RVE RISC-V extensions

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -17,33 +17,15 @@
 
 # Author: Jose Miranda, Juan Sapriza (jose.mirandacalero / juan.sapriza @epfl.ch)
 
-MAKE                       = make
-
-# Project options are based on the app to be build (default - hello_world)
-PROJECT  ?= hello_world
-
-# Linker options are 'on_chip' (default),'flash_load','flash_exec'
-LINKER   ?= on_chip
-
-# Target options are 'sim' (default), 'pynq-z2', and 'nexys-a7-100t'
-TARGET   ?= sim
-
-# Compiler options are 'gcc' (default) and 'clang'
-COMPILER ?= gcc
-
-# Compiler prefix options are 'riscv32-unknown-' (default)
-COMPILER_PREFIX ?= riscv32-unknown-
-
-# Arch options are any RISC-V ISA string supported by the CPU. Default 'rv32imc'
-ARCH     ?= rv32imc
+MAKE     = make
 
 # Path relative from the location of sw/Makefile from which to fetch source files. The directory of that file is the default value.
-SOURCE 	 ?= $(".")
+SOURCE 	?= $(".")
 
 VERBOSE ?= false
 
 # riscv toolchain install path
-RISCV_XHEEP			?= ~/.riscv
+RISCV_XHEEP			 ?= ~/.riscv
 RISCV_EXE_PREFIX	= $(RISCV_XHEEP)/bin/${COMPILER_PREFIX}elf-
 RISCV_GDB_PATH		= $(RISCV_EXE_PREFIX)gdb
 
@@ -65,19 +47,19 @@ else ifeq ($(ARG), value2)
   $(info $$You are fetching sources from $(source_path) )
 endif
 
-SOURCE_PATH   		       = $(source_path)/
-ROOT_PROJECT               = $(mkfile_path)/
-INC_FOLDERS                = $(mkfile_path)/device/target/$(TARGET)/
-LINK_FOLDER                ?= $(mkfile_path)/linker
+SOURCE_PATH  = $(source_path)/
+ROOT_PROJECT = $(mkfile_path)/
+INC_FOLDERS  = $(mkfile_path)/device/target/$(TARGET)/
+LINK_FOLDER  ?= $(mkfile_path)/linker
 
 # CMake keyword
-CMAKE_DIR=cmake
+CMAKE_DIR = cmake
 
 # to distinguish between cmake distros
 ifeq (, $(shell which cmake3)) # cmake3 is not defined
-CMAKE=cmake
+CMAKE = cmake
 else
-CMAKE=cmake3
+CMAKE = cmake3
 endif
 
 # Export variables to sub-makefiles


### PR DESCRIPTION
Some updates that we missed with the changes to the openhw compiler by default. Also removed duplication of parameters in `sw/makefile`