### PR TITLE
`make venv` fails since latest pip update (26.0)

### DIFF
--- a/util/python-requirements.txt
+++ b/util/python-requirements.txt
@@ -8,10 +8,10 @@ black==24.8.0
 deepdiff
 
 # Development version with OT-specific changes
-git+https://github.com/davideschiavone/fusesoc.git@ot#egg=fusesoc >= 1.11.0
+git+https://github.com/x-heep/fusesoc.git@ot#egg=fusesoc
 
-# Install edalize by hand as pip install git+https://github.com/davideschiavone/edalize.git
-git+https://github.com/davideschiavone/edalize.git
+# Install edalize by hand as pip install git+https://github.com/x-heep/edalize.git
+git+https://github.com/x-heep/edalize.git
 
 # RISC-V firmware profiler
 git+https://github.com/vlsi-lab/rv_profile.git


### PR DESCRIPTION
There is a deprecated/invalid syntax issue in file `python-requirements.txt`:
```
# Development version with OT-specific changes
git+https://github.com/davideschiavone/fusesoc.git@ot#egg=fusesoc >= 1.11.0
```
That `>= 1.11.0` specifier is not valid for URLs, only for packages in the index.
This syntax has been deprecated since PIP 23.0 (from 2023), but until recently it merely triggered a warning.  However, since PIP 26.0 (released on 2026-01-31) the syntax is no longer supported at all and it causes an error when running `make venv`:[^1]
```
[...]
./.venv/bin/pip install -r util/python-requirements.txt -r docs/python-requirements.txt
error: invalid-egg-fragment

× The 'fusesoc >= 1.11.0' egg fragment is invalid
╰─> from 'git+https://github.com/davideschiavone/fusesoc.git@ot#egg=fusesoc >= 1.11.0'

hint: Version specifiers are silently ignored for URL references. Remove them. 
make: *** [Makefile.venv:233: .venv/bin/.initialized-with-Makefile.venv] Error 1
```
Note that, since `make venv` will always pull the *newest* version of PIP, this issue affects older commits retroactively, even those that used to work one week ago.

Removing the `>= 1.11.0` fixes the issue.  (Note that this doesn't do anything when used with git repos anyway.)

## Reproduction steps

1.  Be January 31 2026 or later.
2.  Get a machine with Python 3.9+ (3.8 will use PIP 25.0 at most which doesn't have this issue, since support for Python 3.8 was dropped on PIP 25.1).
3.  Clone a fresh copy of X-HEEP (or, if you already have an X-HEEP project, do `make clean-venv` or `rm -R .venv/` to ensure that there's no `.venv`).
4.  Run `make venv`.
5.  Observe the error.

[^1]: https://github.com/pypa/pip/commit/42154e8 "Remove support for non-bare egg fragments -- They were deprecated from all the way back to January 2023 🙃."