### PR TITLE
:bug: Fix CPU wrappers syntax so Vivado stops whining

### DIFF
--- a/hw/core-v-mini-mcu/cv32e40px_xif_wrapper.sv
+++ b/hw/core-v-mini-mcu/cv32e40px_xif_wrapper.sv
@@ -173,13 +173,13 @@ module cv32e40px_xif_wrapper
 
   cv32e40px_top #(
       .COREV_X_IF(X_INTERFACE),
-      .COREV_PULP,
-      .COREV_CLUSTER,
-      .FPU,
-      .FPU_ADDMUL_LAT,
-      .FPU_OTHERS_LAT,
-      .ZFINX,
-      .NUM_MHPMCOUNTERS
+      .COREV_PULP(COREV_PULP),
+      .COREV_CLUSTER(COREV_CLUSTER),
+      .FPU(FPU),
+      .FPU_ADDMUL_LAT(FPU_ADDMUL_LAT),
+      .FPU_OTHERS_LAT(FPU_OTHERS_LAT),
+      .ZFINX(ZFINX),
+      .NUM_MHPMCOUNTERS(NUM_MHPMCOUNTERS)
   ) cv32e40px_top_i (
       .clk_i,
       .rst_ni,

--- a/hw/core-v-mini-mcu/cve2_xif_wrapper.sv
+++ b/hw/core-v-mini-mcu/cve2_xif_wrapper.sv
@@ -69,9 +69,6 @@ module cve2_xif_wrapper
     input  logic fetch_enable_i,
     output logic core_sleep_o
 );
-  // Parameters
-  localparam bit Cve2XInterface = X_INTERFACE != '0;
-
   // CVE2 X-IF signals
   logic                    cve2_x_issue_valid;
   logic                    cve2_x_issue_ready;
@@ -146,11 +143,11 @@ module cve2_xif_wrapper
   // CV32E20 CORE
   // ------------
   cve2_top #(
-      .MHPMCounterNum,
-      .MHPMCounterWidth,
-      .RV32E,
-      .RV32M,
-      .XInterface(Cve2XInterface)
+      .MHPMCounterNum(MHPMCounterNum),
+      .MHPMCounterWidth(MHPMCounterWidth),
+      .RV32E(RV32E),
+      .RV32M(RV32M),
+      .XInterface(X_INTERFACE != '0)
   ) u_cve2_top (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
Fix bug introduced with #878 with implicit parameter passing, that as it turns out is not supported by Vivado