### PR TITLE
Casted all mux signals into the same length

### DIFF
--- a/hw/system/pad_control/data/pad_control.hjson.tpl
+++ b/hw/system/pad_control/data/pad_control.hjson.tpl
@@ -28,7 +28,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits: "${xheep.get_padring().get_muxed_pad_select_width()-1}:0", name: "PAD_MUX_${pad.name.upper()}", desc: "Pad Mux ${pad.name.upper()} Reg" }
+        { bits: "${(len(pad.pins)-1).bit_length()-1}:0", name: "PAD_MUX_${pad.name.upper()}", desc: "Pad Mux ${pad.name.upper()} Reg" }
       ]
     }
   % endif

--- a/hw/system/pad_control/rtl/pad_control.sv.tpl
+++ b/hw/system/pad_control/rtl/pad_control.sv.tpl
@@ -81,7 +81,7 @@ module pad_control #(
 
 % for pad in xheep.get_padring().pad_list:
     % if len(pad.pins) > 1:
-        assign pad_muxes_o[PAD_${pad.name.upper()}] = $unsigned(reg2hw.pad_mux_${pad.name.lower()}.q);
+        assign pad_muxes_o[PAD_${pad.name.upper()}] = ${xheep.get_padring().get_muxed_pad_select_width()}'(reg2hw.pad_mux_${pad.name.lower()}.q);
     % endif
 % endfor
 


### PR DESCRIPTION
Because the muxing is done in a matrix, all registers need to be of the same size so we can simply assign them

```sv    
output logic [NUM_PAD-1:0][2:0] pad_muxes_o
```