### PR TITLE
move read-only sections to ram0

### DIFF
--- a/scripts/building/mem_usage.py
+++ b/scripts/building/mem_usage.py
@@ -367,7 +367,10 @@ def get_regions(section_headers):
         elif section_name in flash_data_sections:
             region_type = "f"
             name = "FLASH data"
-        elif section_name in code_sections or "X" in section["flags"] or "W" not in section["flags"]:
+        elif "W" not in section["flags"] and "X" not in section["flags"]:
+            region_type = "R"
+            name = "rodata"
+        elif section_name in code_sections or "X" in section["flags"]:
             region_type = "C"
             name = "code"
 
@@ -557,13 +560,64 @@ def interval_overlap(start_a, end_a, start_b, end_b):
     return max(0, min(end_a, end_b) - max(start_a, start_b))
 
 
+def summarize_memory_bank(name, section, regions):
+    section_start = section["origin"]
+    section_end = section_start + section["length"]
+    bank_regions = []
+    symbol_labels = {"C": "Code", "R": "ROData", "d": "Data", "i": "IL data"}
+    symbol_order = ("C", "R", "d", "i")
+
+    for region in regions:
+        overlap_start = max(region["start_add"], section_start)
+        overlap_end = min(region["end_add"], section_end)
+        if overlap_start >= overlap_end or region["name"] == "FLASH data":
+            continue
+        bank_regions.append(
+            {
+                "name": region["name"],
+                "symbol": region["symbol"],
+                "start_add": overlap_start,
+                "end_add": overlap_end,
+                "size_B": overlap_end - overlap_start,
+            }
+        )
+
+    merged_intervals = []
+    for region in sorted(bank_regions, key=lambda item: item["start_add"]):
+        if not merged_intervals or region["start_add"] > merged_intervals[-1][1]:
+            merged_intervals.append([region["start_add"], region["end_add"]])
+        else:
+            merged_intervals[-1][1] = max(merged_intervals[-1][1], region["end_add"])
+
+    symbols = sorted(
+        {region["symbol"] for region in bank_regions},
+        key=lambda symbol: symbol_order.index(symbol) if symbol in symbol_order else len(symbol_order),
+    )
+
+    return {
+        "name": name,
+        "origin": section_start,
+        "end": section_end,
+        "length": section["length"],
+        "used": sum(region["size_B"] for region in bank_regions),
+        "required": sum(interval_end - interval_start for interval_start, interval_end in merged_intervals),
+        "contents": ", ".join(f"{symbol_labels[symbol]} ({symbol})" for symbol in symbols) if symbols else "-",
+    }
+
+
 def print_summary_and_bank_usage(memory_sections, regions, program_headers, banks):
     summaries = {
         "Code": summarize_region(memory_sections, regions, "code", ("ram0", "FLASH0", "FLASH")),
+        "ROData": summarize_region(memory_sections, regions, "rodata", ("ram0", "FLASH0", "FLASH")),
         "Data": summarize_region(memory_sections, regions, "data", ("ram1", "RAM")),
         "ILdata": summarize_region(memory_sections, regions, "IL data", ()),
     }
     flash_summary = summarize_flash_image(memory_sections, program_headers)
+    ram_bank_summaries = [
+        summarize_memory_bank(name, section, regions)
+        for name, section in sorted(memory_sections.items(), key=lambda item: item[1]["origin"])
+        if not is_flash_section(name)
+    ]
 
     continuous_sizes_kB = [int(bank["size"] / 1024) for bank in banks if bank["type"] == "Cont"]
     interleaved_sizes_kB = [int(bank["size"] / 1024) for bank in banks if bank["type"] == "IntL"]
@@ -584,17 +638,12 @@ def print_summary_and_bank_usage(memory_sections, regions, program_headers, bank
         and any(re.fullmatch(r"FLASH\d+", name) for name in memory_sections)
     )
 
-    print(f"{'Region':<8} {'Mem':<9} {'Start':>8} {'End':>8} {'Sz(kB)':>8} {'Usd(kB)':>8} {'Req(kB)':>8} {'Utilz(%)':>9}")
-    for label in ("Code", "Data", "ILdata"):
-        summary = summaries[label]
-        if summary is None:
-            continue
-        if label == "Code" and flash_code:
-            continue
+    print(f"{'Bank':<8} {'Start':>8} {'End':>8} {'Sz(kB)':>8} {'Usd(kB)':>8} {'Req(kB)':>8} {'Utilz(%)':>9}    Contents")
+    for summary in ram_bank_summaries:
         utilization = 0.0 if summary["length"] == 0 else 100 * summary["required"] / summary["length"]
         print(
-            f"{label + ':':<8} {summary['mem']:<9} {summary['origin']/1024:8.1f} {summary['end']/1024:8.1f} "
-            f"{summary['length']/1024:8.1f} {summary['used']/1024:8.1f} {summary['required']/1024:8.1f} {utilization:9.1f}"
+            f"{summary['name'] + ':':<8} {summary['origin']/1024:8.1f} {summary['end']/1024:8.1f} "
+            f"{summary['length']/1024:8.1f} {summary['used']/1024:8.1f} {summary['required']/1024:8.1f} {utilization:9.1f}    {summary['contents']}"
         )
 
     if summaries["Code"] is not None:

--- a/sw/linker/link.ld.tpl
+++ b/sw/linker/link.ld.tpl
@@ -26,8 +26,8 @@ MEMORY
 }
 
 /*
- * This linker script try to put data in ram1 and code
- * in ram0.
+ * This linker script tries to put writable data in ram1 and executable /
+ * read-only sections in ram0.
 */
 
 SECTIONS
@@ -83,12 +83,8 @@ SECTIONS
   /* read-only sections */
   .rodata         :
   {
-    *(.rodata .rodata.* .gnu.linkonce.r.*)
+    *(.rodata .rodata* .gnu.linkonce.r.*)
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)
-  } >ram0
-  .rodata1        :
-  {
-    *(.rodata1)
   } >ram0
 
   /* second level sbss and sdata, I don't think we need this */

--- a/sw/linker/link_flash_exec.ld.tpl
+++ b/sw/linker/link_flash_exec.ld.tpl
@@ -40,18 +40,24 @@ SECTIONS {
 	KEEP (*(.text.start))
     } >FLASH
 
-    /* The program code and other data goes into FLASH */
+    /* The program code goes into FLASH */
     .text :
     {
         . = ALIGN(4);
         *(.text)           /* .text sections (code) */
         *(.text*)          /* .text* sections (code) */
+        . = ALIGN(4);
+    } >FLASH
+
+    /* Read-only data lives in FLASH as a separate output section. */
+    .rodata :
+    {
         *(.rodata)         /* .rodata sections (constants, strings, etc.) */
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
         *(.srodata)        /* .rodata sections (constants, strings, etc.) */
         *(.srodata*)       /* .rodata* sections (constants, strings, etc.) */
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
+        _etext = .;        /* define a global symbol at end of code-side content */
     } >FLASH
 
     /* This is the initialized data section

--- a/sw/linker/link_flash_load.ld.tpl
+++ b/sw/linker/link_flash_load.ld.tpl
@@ -73,12 +73,18 @@ SECTIONS {
         __text_start = .; /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
         *(.text)           /* .text sections (code) */
         *(.text*)          /* .text* sections (code) */
+       . = ALIGN(4);
+    } >ram0 AT >FLASH0
+    
+    /* Read-only data lives on the code side as a separate output section. */
+    .rodata : ALIGN_WITH_INPUT
+    {
         *(.rodata)         /* .rodata sections (constants, strings, etc.) */
         *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
         *(.srodata)        /* .rodata sections (constants, strings, etc.) */
         *(.srodata*)       /* .rodata* sections (constants, strings, etc.) */
         . = ALIGN(4);
-        _etext = .;        /* define a global symbol at end of code */
+        _etext = .;        /* define a global symbol at end of code-side content */
     } >ram0 AT >FLASH0
 
     /* This is the initialized data section


### PR DESCRIPTION
Align link.ld.tpl and flash linker templates by separating .rodata from .text and placing it in ram0 (code-side). This keeps read-only data consistently on the code bank across on-chip, flash_load, and flash_exec layouts. Update mem_usage.py accordingly: classify .rodata separately and adjust the report to show a bank‑level breakdown (ram0/ram1/etc.) with a clear contents column, which is a more accurate representation of how memory is partitioned than the previous region breakdown