### PR TITLE
Separate register to AXI bridges in dedicated `.core` file

### DIFF
--- a/hw/vendor/pulp_platform_reg_axi_bridges.core
+++ b/hw/vendor/pulp_platform_reg_axi_bridges.core
@@ -1,0 +1,42 @@
+CAPI=2:
+
+# Copyright (c) 2026 EPFL.
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-2.0. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# File: pulp_platform_reg_axi_bridges.core
+# Author(s):
+#   Michele Caon <michele.caon@epfl.ch>
+# Date: 08/05/2026
+# Description: Register Interface <--> AXI bridges
+
+# NOTE: the files included in this IP were separated from the resto of the
+#       register interfaces (`pulp_platform_register_interface.core`) to keep
+#       the main register interface core file independent from the AXI repo, so
+#       projects using only the Register Interface are not forced to depend on
+#       AXI as well.
+
+name: pulp-platform.org::reg_axi_bridges
+desc: "Registere Interface to AXI bridges"
+
+filesets:
+  rtl:
+    depend:
+    - pulp-platform.org::register_interface
+    - pulp-platform.org::axi:0.39.8
+    files:
+    - pulp_platform/register_interface/src/axi_lite_to_reg.sv
+    - pulp_platform/register_interface/src/axi_to_reg_v2.sv
+    - pulp_platform/register_interface/src/reg_to_axi.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+    - rtl

--- a/hw/vendor/pulp_platform_reg_to_axi.core
+++ b/hw/vendor/pulp_platform_reg_to_axi.core
@@ -10,7 +10,7 @@ CAPI=2:
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-# File: pulp_platform_reg_axi_bridges.core
+# File: pulp_platform_reg_to_axi.core
 # Author(s):
 #   Michele Caon <michele.caon@epfl.ch>
 # Date: 08/05/2026
@@ -22,7 +22,7 @@ CAPI=2:
 #       projects using only the Register Interface are not forced to depend on
 #       AXI as well.
 
-name: pulp-platform.org::reg_axi_bridges
+name: pulp-platform.org::reg_to_axi
 desc: "Registere Interface to AXI bridges"
 
 filesets:

--- a/hw/vendor/pulp_platform_register_interface.core
+++ b/hw/vendor/pulp_platform_register_interface.core
@@ -18,6 +18,7 @@ filesets:
     - pulp_platform/register_interface/src/reg_demux.sv
     - pulp_platform/register_interface/src/reg_err_slv.sv
     - pulp_platform/register_interface/src/reg_filter_empty_writes.sv
+    - pulp_platform/register_interface/src/reg_intf.sv
     - pulp_platform/register_interface/src/reg_mux.sv
     - pulp_platform/register_interface/src/reg_to_apb.sv
     - pulp_platform/register_interface/src/reg_to_mem.sv

--- a/hw/vendor/pulp_platform_register_interface.core
+++ b/hw/vendor/pulp_platform_register_interface.core
@@ -8,14 +8,10 @@ name: pulp-platform.org::register_interface
 
 filesets:
   files_rtl:
-    depend:
-    - pulp-platform.org::axi:0.39.8
     files:
     - pulp_platform/register_interface/include/register_interface/assign.svh : {is_include_file: true, include_path: pulp_platform/register_interface/include}
     - pulp_platform/register_interface/include/register_interface/typedef.svh : {is_include_file: true, include_path: pulp_platform/register_interface/include}
     - pulp_platform/register_interface/src/apb_to_reg.sv
-    - pulp_platform/register_interface/src/axi_lite_to_reg.sv
-    - pulp_platform/register_interface/src/axi_to_reg_v2.sv
     - pulp_platform/register_interface/src/periph_to_reg.sv
     - pulp_platform/register_interface/src/reg_cdc.sv
     - pulp_platform/register_interface/src/reg_cut.sv
@@ -24,7 +20,6 @@ filesets:
     - pulp_platform/register_interface/src/reg_filter_empty_writes.sv
     - pulp_platform/register_interface/src/reg_mux.sv
     - pulp_platform/register_interface/src/reg_to_apb.sv
-    - pulp_platform/register_interface/src/reg_to_axi.sv
     - pulp_platform/register_interface/src/reg_to_mem.sv
     - pulp_platform/register_interface/src/reg_to_tlul.sv
     - pulp_platform/register_interface/src/reg_uniform.sv


### PR DESCRIPTION
This PR removes the following files from `pulp_platform_register_interface.core` and places them in a dedicated `pulp_platform_reg_axi_bridges.core` file:
- `pulp_platform/register_interface/src/axi_lite_to_reg.sv`
- `pulp_platform/register_interface/src/axi_to_reg_v2.sv`
- `pulp_platform/register_interface/src/reg_to_axi.sv`

The reason is that the above files depend on AXI definitions from PULP's `axi` repository. Listing them as part of the Register Interface `.core` file forces projects depending on X-HEEP without using AXI to depend on the AXI repo as welland vendorize it. Separating them improves modularity by allowing users to pull in the `register_interface` alone without loosing consistency.