### PR TITLE
Add missing file for fpnew FMA to core file

### DIFF
--- a/hw/vendor/pulp_platform_fpnew.core
+++ b/hw/vendor/pulp_platform_fpnew.core
@@ -16,6 +16,7 @@ filesets:
     - pulp_platform/fpnew/src/fpnew_cast_multi.sv
     - pulp_platform/fpnew/src/fpnew_classifier.sv
     - pulp_platform/fpnew/src/fpnew_divsqrt_multi.sv
+    - pulp_platform/fpnew/src/fpnew_fma.sv
     - pulp_platform/fpnew/src/fpnew_fma_multi.sv
     - pulp_platform/fpnew/src/fpnew_noncomp.sv
     - pulp_platform/fpnew/src/fpnew_opgroup_block.sv


### PR DESCRIPTION
This PR adds `fpnew_fma.sv` to the `pulp_platform_fpnew.core` to support configurations where the FMA is instantiated (in X-HEEP or parent projects).