### PR TITLE
Allow pads to depend from X-HEEP config

### DIFF
--- a/configs/pad_cfg.py
+++ b/configs/pad_cfg.py
@@ -5,12 +5,13 @@
 # Author(s): Juan Sapriza, David Mallasen
 # Description: Pad configuration for X-HEEP
 
+from x_heep_gen.xheep import XHeep
 from x_heep_gen.pads.pad_ring import PadRing
 from x_heep_gen.pads.floorplan import Side
 from x_heep_gen.pads.pin import Input, Output, Inout
 
 
-def config() -> PadRing:
+def config(xheep: XHeep) -> PadRing:
     """
     Build and return the PadRing for the design, including pin definitions and pad mapping.
     For detailed documentation and usage instructions, please refer to docs/source/Configuration/PadConfiguration.md

--- a/docs/source/Configuration/PadConfiguration.md
+++ b/docs/source/Configuration/PadConfiguration.md
@@ -9,7 +9,7 @@ The pad configuration system allows you to define:
 - Pin-to-Pad Mapping: How pins are assigned to physical pads on each side of the chip, including multiplexing (assign multiple pins to the same pad, or a single pin to multiple pads).
 - (Optional) Floorplan: Physical layout of the die and location of the pads.
 
-The configuration is done through a Python `config(xheep: XHeep)` function that returns a `PadRing` object. This approach provides flexibility and programmatic generation of pad configurations and allwos the pad generation to depend on the current X-HEEP configuration passed as an argument. The default pad configuration file can be found in [`configs/pad_cfg.py`](https://github.com/x-heep/x-heep/blob/main/configs/pad_cfg.py).
+The configuration is done through a Python `config(xheep: XHeep)` function that accepts an `XHeep` object as its only argument and returns a `PadRing` object. This approach provides flexibility and programmatic generation of pad configurations and allwos the pad generation to depend on the current X-HEEP configuration passed as an argument. The default pad configuration file can be found in [`configs/pad_cfg.py`](https://github.com/x-heep/x-heep/blob/main/configs/pad_cfg.py).
 
 The default call to `mcu-gen` uses the default pad configuration, but you can specify a custom pad configuration file using the `PADS_CFG` variable:
 

--- a/docs/source/Configuration/PadConfiguration.md
+++ b/docs/source/Configuration/PadConfiguration.md
@@ -9,7 +9,7 @@ The pad configuration system allows you to define:
 - Pin-to-Pad Mapping: How pins are assigned to physical pads on each side of the chip, including multiplexing (assign multiple pins to the same pad, or a single pin to multiple pads).
 - (Optional) Floorplan: Physical layout of the die and location of the pads.
 
-The configuration is done through a Python `config()` function that returns a `PadRing` object. This approach provides flexibility and programmatic generation of pad configurations. The default pad configuration file can be found in `configs/pad_cfg.py`.
+The configuration is done through a Python `config(xheep: XHeep)` function that returns a `PadRing` object. This approach provides flexibility and programmatic generation of pad configurations and allwos the pad generation to depend on the current X-HEEP configuration passed as an argument. The default pad configuration file can be found in [`configs/pad_cfg.py`](https://github.com/x-heep/x-heep/blob/main/configs/pad_cfg.py).
 
 The default call to `mcu-gen` uses the default pad configuration, but you can specify a custom pad configuration file using the `PADS_CFG` variable:
 
@@ -145,7 +145,7 @@ floorplan = FloorplanDimensions(
 Once pins and mapping are defined, create the PadRing:
 
 ```python
-def config() -> PadRing:
+def config(xheep: XHeep) -> PadRing:
     # ... define pins and mapping ...
 
     padring = PadRing(

--- a/util/mcu_gen.py
+++ b/util/mcu_gen.py
@@ -83,7 +83,9 @@ def generate_xheep(args):
             raise SystemExit(sys.exc_info()[1])
 
     # Load pads HJSON configuration file
-    pad_ring = x_heep_gen.load_config.load_pad_cfg(pathlib.PurePath(str(args.pads_cfg)))
+    pad_ring = x_heep_gen.load_config.load_pad_cfg(
+        pathlib.PurePath(str(args.pads_cfg)), xheep
+    )
     if pad_ring is None:
         exit(f"Error loading pads configuration file: {args.pads_cfg}")
     xheep.set_padring(pad_ring)

--- a/util/x_heep_gen/load_config.py
+++ b/util/x_heep_gen/load_config.py
@@ -12,7 +12,7 @@ from .memory_ss.memory_ss import MemorySS
 from .memory_ss.linker_section import LinkerSection
 from .memory_ss.linker_subsection import LinkerSubsection
 from .peripherals.peripheral_config_loader import load_peripherals_config
-from .xheep import BusType, XHeep, CvXIf
+from .xheep import BusType, XHeep, CvXIf, PadRing
 
 
 def to_int(input) -> Union[int, None]:
@@ -324,14 +324,15 @@ def load_cfg_file(f: PurePath) -> XHeep:
         raise RuntimeError(f"unsupported file extension {f.suffix}")
 
 
-def load_pad_cfg(pad_cfg_path: PurePath):
+def load_pad_cfg(pad_cfg_path: PurePath, xheep: XHeep) -> PadRing:
     """
     Load pad configuration a Python file and build the PadRing.
 
     Imports the Python module and calls the config() function which must
-    not take any parameters and return a PadRing instance.
+    take an XHeep object as a parameter and return a PadRing instance.
 
     :param PurePath pad_cfg_path: Path to .py configuration file
+    :param XHeep xheep: the XHeep object representing the system configuration
     :return: Built PadRing object ready for template generation
     """
     if not isinstance(pad_cfg_path, PurePath):
@@ -343,4 +344,4 @@ def load_pad_cfg(pad_cfg_path: PurePath):
     spec = importlib.util.spec_from_file_location("configs._config", pad_cfg_path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return mod.config()
+    return mod.config(xheep)


### PR DESCRIPTION
This PR changes the signature of the `config()` function that defines the pads to accept a mandatory `XHeep` object as an argument:
```python
def config(xheep: XHeep) -> PadRing:
```

This enables using the `mcu-gen` configuration to parameterize the pad ring generation. For example, I2S pads might only be defined if the I2S peripheral is actually added to X-HEEP. 