### PR TITLE
Enhancing toolchain configuration robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ flow/OpenROAD-flow-scripts
 /docs/source/Configuration/xheep_gen
 
 # User-dependent configuration files
+.python-version
 .vscode
 .continue
 private/

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,22 @@ VENVDIR?=$(WORKDIR)/.venv
 REQUIREMENTS_TXT ?= util/python-requirements.txt docs/python-requirements.txt
 include Makefile.venv
 
+# Decide: conda-style if conda OR pyenv is active
+PYTHON_PATH := $(shell which python 2>/dev/null)
+PYENV_USED := $(findstring .pyenv,$(PYTHON_PATH))
+USE_GLOBAL_ENV := $(strip \
+	$(or $(CONDA_DEFAULT_ENV),$(PYENV_USED)) \
+)
+
 # FUSESOC and Python values (default)
-ifndef CONDA_DEFAULT_ENV
+ifeq ($(USE_GLOBAL_ENV),)
 $(info USING VENV)
 FUSESOC 	= $(PWD)/$(VENV)/fusesoc
 PYTHON  	= $(PWD)/$(VENV)/python
 RV_PROFILE 	= $(PWD)/$(VENV)/rv_profile
 AREA_PLOT  	= $(PWD)/$(VENV)/area-plot
 else
-$(info USING MINICONDA $(CONDA_DEFAULT_ENV))
+$(info USING MINICONDA/PYENV $(shell which python))
 FUSESOC 	:= $(shell which fusesoc)
 PYTHON  	:= $(shell which python)
 RV_PROFILE  := $(shell which rv_profile)

--- a/core-v-mini-mcu.core
+++ b/core-v-mini-mcu.core
@@ -390,6 +390,8 @@ targets:
           - '-CFLAGS "-Wall -fpermissive"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
+          - "-Wno-SYNCASYNCNET"
+          - "-Wno-MULTIDRIVEN"
 
   sim_sc:
     <<: *default_target

--- a/docs/source/GettingStarted/Setup.md
+++ b/docs/source/GettingStarted/Setup.md
@@ -44,7 +44,7 @@ To use `X-HEEP`, first you will need to install some OS dependencies. We recomme
 
 The following command `apt` command should install every required package:
 ```bash
-sudo apt install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev help2man perl make g++ libfl2 libfl-dev zlibc zlib1g zlib1g-dev ccache mold libgoogle-perftools-dev numactl libelf-dev
+sudo apt install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev help2man perl make g++ libfl2 libfl-dev zlibc zlib1g zlib1g-dev ccache mold libgoogle-perftools-dev numactl libelf-dev liblz4-dev
 ```
 
 Errors occurring when installing the following packages may be ignored:

--- a/util/waiver-gen.py
+++ b/util/waiver-gen.py
@@ -19,6 +19,8 @@ def get_verilator_major_version():
         )
         output = result.stdout
         match = re.search(r"rev v(\d+)\.\d+", output)
+        if not match:
+            match = re.search(r"Verilator (\d+)\.\d+", output)
 
         if not match:
             print(


### PR DESCRIPTION
This PR addresses toolchain configuration robustness.

### Key Changes

1. **Fix Verilator Version Parsing Bug**
   * **Problem:** The toolchain configuration script crashes when parsing development builds or homebrew version of Verilator. For example, a version string like `"Verilator 5.048 2026-04-26 rev vUNKNOWN-built20260426"` breaks the existing regex/parsing logic.

2. **Enhance Environment Support for `pyenv`**
   * Since many developers prefer pyenv over managing a heavy Conda environment or modifying their global system Python, adding this support is a great quality-of-life improvement that keeps the experience seamless.

3. **Add Forward Compatibility for Verilator v5.050+**
   * *Note:* Verilator `v5.048` contains a DPI export pointer bug. I have fixed this upstream in Verilator via [verilator/verilator#7751](https://github.com/verilator/verilator/pull/7751). Full stability is expected moving forward with `v5.050` or any development version containing that upstream patch.